### PR TITLE
Test on another PostgreSQL version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ addons:
 julia:
   - 0.6
   - nightly
+env:
+  - POSTGRESQL_VERSION=9.4
+  - POSTGRESQL_VERSION=9.6
+before_install:
+  - sudo service postgresql stop && sudo service postgresql start $POSTGRESQL_VERSION
+  - psql -U postgres -tc 'SHOW server_version'
 matrix:
   allow_failures:
     - julia: nightly

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -63,8 +63,9 @@ show_option(str::String) = string(replace(str, [' ', '\\'], s -> "\\$s"))
 show_option(bool::Bool) = ifelse(bool, 't', 'f')
 show_option(num::Real) = num
 
+# values containing spaces may not work correctly on PostgreSQL versions before 9.6
 const CONNECTION_OPTION_DEFAULTS = Dict{String, String}(
-    "DateStyle" => "ISO, YMD",
+    "DateStyle" => "ISO,YMD",
     "IntervalStyle" => "iso_8601",
     "TimeZone" => "UTC",
 )


### PR DESCRIPTION
Now does 9.4 as well. We could add more if needed.

I tried to figure out the escaping rules for options on 9.4 but I couldn't. It turns out the option with a space that we're using doesn't require one, so that's my solution for now.