### PR TITLE
resolving issue #33 (reducing timestamp resolution to milliseconds for julia DateTime)

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -227,10 +227,6 @@ function Base.parse(::Type{ZonedDateTime}, pqv::PQValue{PQ_SYSTEM_TYPES[:timesta
         return ZonedDateTime(typemin(DateTime), tz"UTC")
     end
 
-    # Cut off digits after the third after the decimal point,
-    # since DateTime in Julia currently handles only milliseconds, see Issue #33
-    str = replace(str, r"(\.[\d]{3})\d+", s"\g<1>")
-
     for fmt in TIMESTAMPTZ_FORMATS[1:end-1]
         try
             return parse(ZonedDateTime, str, fmt)
@@ -238,6 +234,9 @@ function Base.parse(::Type{ZonedDateTime}, pqv::PQValue{PQ_SYSTEM_TYPES[:timesta
             continue
         end
     end
+    # Cut off digits after the third after the decimal point,
+    # since DateTime in Julia currently handles only milliseconds, see Issue #33
+    str = replace(str, r"(\.[\d]{3})\d+", s"\g<1>")
     return parse(ZonedDateTime, str, TIMESTAMPTZ_FORMATS[end])
 end
 

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -204,6 +204,9 @@ function Base.parse(::Type{DateTime}, pqv::PQValue{PQ_SYSTEM_TYPES[:timestamp]})
         return typemin(DateTime)
     end
 
+    # Cut off digits after the third after the decimal point,
+    # since DateTime in Julia currently handles only milliseconds, see Issue #33
+    str = replace(str, r"(\.[\d]{3})\d+", s"\g<1>")
     return parse(DateTime, str, TIMESTAMP_FORMAT)
 end
 
@@ -234,7 +237,9 @@ function Base.parse(::Type{ZonedDateTime}, pqv::PQValue{PQ_SYSTEM_TYPES[:timesta
             continue
         end
     end
-
+    # Cut off digits after the third after the decimal point,
+    # since DateTime in Julia currently handles only milliseconds, see Issue #33
+    str = replace(str, r"(\.[\d]{3})\d+", s"\g<1>")
     return parse(ZonedDateTime, str, TIMESTAMPTZ_FORMATS[end])
 end
 

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -230,6 +230,10 @@ function Base.parse(::Type{ZonedDateTime}, pqv::PQValue{PQ_SYSTEM_TYPES[:timesta
         return ZonedDateTime(typemin(DateTime), tz"UTC")
     end
 
+    # Cut off digits after the third after the decimal point,
+    # since DateTime in Julia currently handles only milliseconds, see Issue #33
+    str = replace(str, r"(\.[\d]{3})\d+", s"\g<1>")
+
     for fmt in TIMESTAMPTZ_FORMATS[1:end-1]
         try
             return parse(ZonedDateTime, str, fmt)
@@ -237,9 +241,6 @@ function Base.parse(::Type{ZonedDateTime}, pqv::PQValue{PQ_SYSTEM_TYPES[:timesta
             continue
         end
     end
-    # Cut off digits after the third after the decimal point,
-    # since DateTime in Julia currently handles only milliseconds, see Issue #33
-    str = replace(str, r"(\.[\d]{3})\d+", s"\g<1>")
     return parse(ZonedDateTime, str, TIMESTAMPTZ_FORMATS[end])
 end
 

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -217,9 +217,6 @@ const TIMESTAMPTZ_FORMATS = (
     dateformat"y-m-d HH:MM:SS.sz",
     dateformat"y-m-d HH:MM:SS.ssz",
     dateformat"y-m-d HH:MM:SS.sssz",
-    dateformat"y-m-d HH:MM:SS.ssssz",
-    dateformat"y-m-d HH:MM:SS.sssssz",
-    dateformat"y-m-d HH:MM:SS.ssssssz",
 )
 function Base.parse(::Type{ZonedDateTime}, pqv::PQValue{PQ_SYSTEM_TYPES[:timestamptz]})
     str = string_view(pqv)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -522,6 +522,8 @@ end
                         ("0::bool", false),
                         ("false", false),
                         ("TIMESTAMP '2004-10-19 10:23:54'", DateTime(2004, 10, 19, 10, 23, 54)),
+                        ("TIMESTAMP '2004-10-19 10:23:54.123'", DateTime(2004, 10, 19, 10, 23, 54,123)),
+                        ("TIMESTAMP '2004-10-19 10:23:54.1234'", DateTime(2004, 10, 19, 10, 23, 54,123)),
                         ("'infinity'::timestamp", typemax(DateTime)),
                         ("'-infinity'::timestamp", typemin(DateTime)),
                         ("'epoch'::timestamp", DateTime(1970, 1, 1, 0, 0, 0)),


### PR DESCRIPTION
This sure is an ugly hack, working with regexpes on the string representation of a timestamp, but it should work for now. Otherwise people might suddenly get an InexactError if they execute a select with timestamp columns wich contain sub-millisecond resolution. Should be revisited when a new Julia DateTime with microseconds becomes available.