### PR TITLE
Add LibPQ.CopyIn for `COPY FROM STDIN` queries

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -69,3 +69,26 @@ Data.stream!(
 
 execute(conn, "COMMIT;")
 ```
+
+### `COPY`
+
+An alternative to repeated `INSERT` queries is the PostgreSQL `COPY` query.
+`LibPQ.CopyIn` makes it easier to stream data to the server using a `COPY FROM STDIN` query.
+
+```julia
+using LibPQ, DataFrames
+
+conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER")
+
+row_strings = imap(eachrow(df)) do row
+    if ismissing(row[:yes_nulls])
+        "$(row[:no_nulls]),\n"
+    else
+        "$(row[:no_nulls]),$(row[:yes_nulls])\n"
+    end
+end
+
+copyin = LibPQ.CopyIn("COPY libpqjl_test FROM STDIN (FORMAT CSV);", row_strings)
+
+close(conn)
+```

--- a/docs/src/pages/api.md
+++ b/docs/src/pages/api.md
@@ -43,6 +43,13 @@ num_params(::LibPQ.Statement)
 Base.show(::IO, ::LibPQ.Statement)
 ```
 
+### Copy
+
+```@docs
+LibPQ.CopyIn
+execute(::LibPQ.Connection, ::LibPQ.CopyIn)
+```
+
 ### DataStreams Integration
 
 ```@docs

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -193,7 +193,7 @@ function Connection(str::AbstractString; throw_error::Bool=true, kwargs...)
 
     # Make the connection
     jl_conn = Connection(libpq_c.PQconnectdbParams(keywords, values, false); kwargs...)
-    
+
     # If password needed and not entered, prompt the user
     if libpq_c.PQconnectionNeedsPassword(jl_conn.conn) == 1
         push!(keywords, "password")
@@ -1180,6 +1180,7 @@ end
 ### PREPARE END
 
 include("parsing.jl")
+include("copy.jl")
 include("datastreams.jl")
 
 Base.@deprecate clear!(jl_result::Result) close(jl_result)

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -1,0 +1,61 @@
+"""
+    CopyIn(query, data_itr) -> CopyIn
+
+Create a `CopyIn` query instance which can be executed to send data to PostgreSQL via a
+`COPY <table_name> FROM STDIN` query.
+
+`query` must be a `COPY FROM STDIN` query as described in the [PostgreSQL documentation](https://www.postgresql.org/docs/10/static/sql-copy.html).
+`COPY FROM` queries which use a file or `PROGRAM` source can instead use the standard
+[`execute`](@ref) query interface.
+
+`data_itr` is an iterable containing chunks of data to send to PostgreSQL.
+The data can be divided up into arbitrary buffers as it will be reconstituted on the server.
+The iterated items must be `AbstractString`s or `Array{UInt8}`s.
+"""
+struct CopyIn
+    query::String
+    data_itr
+end
+
+function put_copy_data(jl_conn::Connection, data::Union{Array{UInt8}, AbstractString})
+    libpq_c.PQputCopyData(jl_conn.conn, data, sizeof(data))
+end
+
+function put_copy_end(jl_conn::Connection)
+    libpq_c.PQputCopyEnd(jl_conn.conn, C_NULL)
+end
+
+"""
+    execute(jl_conn::Connection, copyin::CopyIn, args...;
+        throw_error::Bool=true, kwargs...
+    ) -> Result
+
+Runs [`execute`](@ref execute(::Connection, ::String)) on `copyin`'s query, then sends
+`copyin`'s data to the server.
+
+All other arguments are passed through to the `execute` call for the initial query.
+"""
+function execute(jl_conn::Connection, copy::CopyIn, args...; throw_error=true, kwargs...)
+    level = throw_error ? error : warn
+
+    result = execute(jl_conn, copy.query, args...; throw_error=throw_error, kwargs...)
+    result_status = status(result)
+
+    if result_status != libpq_c.PGRES_COPY_IN
+        if !(result_status in (libpq_c.PGRES_BAD_RESPONSE, libpq_c.PGRES_FATAL_ERROR))
+            level(LOGGER, "Expected PGRES_COPY_IN after COPY query, got $result_status")
+        end
+        return result
+    end
+
+    for chunk in copy.data_itr
+        put_copy_data(jl_conn, chunk)
+    end
+
+    status_code = put_copy_end(jl_conn)
+    if status_code == -1
+        level(LOGGER, error_message(jl_conn))
+    end
+
+    return Result(libpq_c.PQgetResult(jl_conn.conn), jl_conn)
+end

--- a/src/headers/libpq-fe.jl
+++ b/src/headers/libpq-fe.jl
@@ -536,7 +536,7 @@ function PQnotifies(conn)
     ccall((:PQnotifies, LIBPQ_HANDLE), Ptr{PGnotify}, (Ptr{PGconn},), conn)
 end
 
-function PQputCopyData(conn, buffer, nbytes::Cint)
+function PQputCopyData(conn, buffer, nbytes)
     ccall((:PQputCopyData, LIBPQ_HANDLE), Cint, (Ptr{PGconn}, Cstring, Cint), conn, buffer, nbytes)
 end
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
+DataFrames
 NamedTuples


### PR DESCRIPTION
This only supports copying into the database for now, and the docs maybe misleadingly indicate that going row by row is a good idea (it might not be, I haven't checked yet). 

This should help address #50 