### PR TITLE
Add support for Tables.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /docs/site/
 /deps/deps.jl
 /deps/usr/
+/deps/build.log

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,6 +2,7 @@ julia 0.7
 BinaryProvider 0.4
 Compat 1.1
 DataStreams 0.4
+Tables
 DocStringExtensions
 Decimals 0.3.1
 IterTools 1

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -7,6 +7,7 @@ using Compat.Dates
 using DocStringExtensions
 using Decimals
 using DataStreams
+using Tables
 using Base.Iterators: zip, product
 using IterTools: imap
 using LayerDicts
@@ -1187,6 +1188,7 @@ end
 include("parsing.jl")
 include("copy.jl")
 include("datastreams.jl")
+include("tables.jl")
 
 Base.@deprecate clear!(jl_result::Result) close(jl_result)
 

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,0 +1,66 @@
+Tables.istable(::Type{<:Result}) = true
+Tables.rowaccess(::Type{<:Result}) = true
+Tables.rows(r::Result) = r
+
+Base.eltype(r::Result) = Row
+Base.length(r::Result) = num_rows(r)
+
+function Tables.schema(r::Result)
+    types = map(r.not_null, column_types(r)) do not_null, col_type
+        not_null ? col_type : Union{col_type, Missing}
+    end
+    return Tables.Schema(types, map(Symbol, column_names(r)))
+end
+
+function Base.iterate(r::Result, (len, row)=(length(r), 1))
+    row > len && return nothing
+    return Row(result, row), (len, row + 1)
+end
+
+struct Row
+    result::Result
+    row::Int
+end
+
+Base.propertynames(r::Row) = column_names(getfield(r, :result))
+
+function Base.getproperty(pqrow::Row, name::Symbol)
+    jl_result = getfield(pqrow, :result)
+    row = getfield(pqrow, :row)
+    col = column_number(jl_result, name)
+    if libpq_c.PQgetisnull(jl_result.result, row - 1, col - 1) == 1
+        return missing
+    else
+        oid = jl_result.column_oids[col]
+        return jl_result.column_funcs[col](PQValue{oid}(jl_result, row, col))  # ::_non_null_type(T) except https://github.com/JuliaData/Missings.jl/issues/80
+    end
+end
+
+# sink
+function load!(table::T, connection::Connection, query::AbstractString) where {T}
+    Tables.istable(T) || throw(ArgumentError("$T doesn't support the required Tables.jl interface"))
+    stmt = prepare(connection, query)
+    rows = Tables.rows(table)
+    state = iterate(rows)
+    state === nothing && return
+    st, row = state
+    names = propertynames(row)
+    sch = Tables.Schema(names, nothing)
+    parameters = Vector{Parameter}(undef, length(names))
+    while true
+        Tables.eachcolumn(sch, row) do val, col, nm
+            parameters[col] = if ismissing(val)
+                missing
+            elseif val isa AbstractString
+                convert(String, val)
+            else
+                string(val)
+            end
+        end
+        close(execute(stmt, parameters; throw_error=true))
+        state = iterate(rows, st)
+        state === nothing && break
+        row, st = state
+    end
+    return
+end


### PR DESCRIPTION
I haven't had a chance to really test this, but wanted to put up what I had. My plan is to deprecate DataStreams in favor of Tables.jl since it provides similar (and simplified) functionality; Tables.jl is 0.7-only though, so no rush here. Let me know what your timeline looks like and I can chip more and get a postgres docker server running to test some stuff.