### PR TITLE
Add tuple parameters to execute

### DIFF
--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -808,7 +808,7 @@ end
 """
     execute(
         {jl_conn::Connection, query::AbstractString | stmt::Statement},
-        [parameters::AbstractVector,]
+        [parameters::Union{AbstractVector, Tuple},]
         throw_error::Bool=true,
         column_types::AbstractDict=ColumnTypeMap(),
         type_map::AbstractDict=LibPQ.PQTypeMap(),
@@ -847,7 +847,7 @@ end
 function execute(
     jl_conn::Connection,
     query::AbstractString,
-    parameters::AbstractVector;
+    parameters::Union{AbstractVector, Tuple};
     throw_error::Bool=true,
     kwargs...
 )
@@ -877,6 +877,11 @@ Convert parameters to strings which can be passed to libpq, propagating `missing
 function string_parameters end
 
 string_parameters(parameters::AbstractVector{<:Parameter}) = parameters
+
+# Tuples of parameters
+string_parameters(parameters::Tuple{Vararg{Parameter}}) = collect(parameters)
+
+string_parameters(parameters::Tuple) = string_parameters(collect(parameters))
 
 # vector which can't contain missing
 string_parameters(parameters::AbstractVector) = map(string, parameters)
@@ -1137,7 +1142,7 @@ end
 
 function execute(
     stmt::Statement,
-    parameters::AbstractVector;
+    parameters::Union{AbstractVector, Tuple};
     throw_error::Bool=true,
     kwargs...
 )

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -879,8 +879,6 @@ function string_parameters end
 string_parameters(parameters::AbstractVector{<:Parameter}) = parameters
 
 # Tuples of parameters
-string_parameters(parameters::Tuple{Vararg{Parameter}}) = collect(parameters)
-
 string_parameters(parameters::Tuple) = string_parameters(collect(parameters))
 
 # vector which can't contain missing


### PR DESCRIPTION
The automatic promotion of array elements in Julia can lead to bugs when executing
stored queries with LibPQ.jl. For example, when inserting a row with both integer
and double precision columns, the current API of LibPQ.jl requires you to do
something like `execute(stmt, [1, 2.0])`, but the parameters will be promoted by
Julia to `[1.0, 2.0]`, causing an error. The way to avoid this catch with the
current API is to pass the parameters as `Real[1, 2.0]` or `Any[1, 2.0]`.

This commit allows parameters to `execute` to be a `Tuple`, which avoids these
pitfalls with automatic promotion. The way to use the expanded API would be
`execute(stmt, (1, 2.0))`.