### PR TITLE
Update CopyIn example

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -90,5 +90,7 @@ end
 
 copyin = LibPQ.CopyIn("COPY libpqjl_test FROM STDIN (FORMAT CSV);", row_strings)
 
+execute(conn, copyin)
+
 close(conn)
 ```


### PR DESCRIPTION
The current CopyIn example creates, but does not use, a COPY query. I have added a line to the demonstration to show how that query should be used.