### PR TITLE
Support overriding options (for supporting non-standard PostgreSQL-like servers)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,7 @@ makedocs(;
         "Home" => "index.md",
         "Type Conversions" => "pages/type-conversions.md",
         "API" => "pages/api.md",
+        "FAQ" => "pages/faq.md",
     ],
     repo="https://github.com/invenia/LibPQ.jl/blob/{commit}{path}#L{line}",
     sitename="LibPQ.jl",

--- a/docs/src/pages/faq.md
+++ b/docs/src/pages/faq.md
@@ -1,0 +1,12 @@
+# Frequently Asked Questions
+
+## Can I use LibPQ.jl with Amazon Redshift?
+
+Yes.
+However, LibPQ.jl by default sets some client options to make interactions more reliable.
+Unsupported options must be disabled for Redshift to allow connections.
+To override all options, pass an empty `Dict{String, String}`:
+
+```julia
+conn = LibPQ.Connection("dbname=myredshift"; options=Dict{String, String}())
+```


### PR DESCRIPTION
Should fix #71 