### PR TITLE
Fix links for linkcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 LibPQ.jl is a Julia wrapper for the PostgreSQL `libpq` C library.
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/LibPQ.jl/stable)
-[![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://invenia.github.io/LibPQ.jl/latest)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/LibPQ.jl/stable/)
+[![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://invenia.github.io/LibPQ.jl/latest/)
 [![Build Status](https://travis-ci.org/invenia/LibPQ.jl.svg?branch=master)](https://travis-ci.org/invenia/LibPQ.jl)
 [![CodeCov](https://codecov.io/gh/invenia/LibPQ.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/invenia/LibPQ.jl)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,7 @@
 # LibPQ
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/LibPQ.jl/stable)
-[![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://invenia.github.io/LibPQ.jl/latest)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/LibPQ.jl/stable/)
+[![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://invenia.github.io/LibPQ.jl/latest/)
 [![Build Status](https://travis-ci.org/invenia/LibPQ.jl.svg?branch=master)](https://travis-ci.org/invenia/LibPQ.jl)
 [![CodeCov](https://codecov.io/gh/invenia/LibPQ.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/invenia/LibPQ.jl)
 
@@ -53,7 +53,7 @@ close(conn)
 #### A Note on Bulk Insertion
 
 When inserting a large number of rows, wrapping your insert queries in a transaction will greatly increase performance.
-See the PostgreSQL documentation [14.4.1. Disable Autocommit](https://www.postgresql.org/docs/10/static/populate.html#DISABLE-AUTOCOMMIT) for more information.
+See the PostgreSQL documentation [14.4.1. Disable Autocommit](https://www.postgresql.org/docs/10/populate.html#DISABLE-AUTOCOMMIT) for more information.
 
 Concretely, this means surrounding your query like this:
 

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -143,7 +143,7 @@ Base.broadcastable(c::Connection) = Ref(c)
     handle_new_connection(jl_conn::Connection; throw_error=true) -> Connection
 
 Check status and handle errors for newly-created connections.
-Also set the client encoding ([23.3. Character Set Support](https://www.postgresql.org/docs/10/static/multibyte.html))
+Also set the client encoding ([23.3. Character Set Support](https://www.postgresql.org/docs/10/multibyte.html))
 to `jl_conn.encoding`.
 
 If `throw_error` is `true`, an error will be thrown if the connection's status is
@@ -179,7 +179,7 @@ end
     ) -> Connection
 
 Create a `Connection` from a connection string as specified in the PostgreSQL
-documentation ([33.1.1. Connection Strings](https://www.postgresql.org/docs/10/static/libpq-connect.html#LIBPQ-CONNSTRING)).
+documentation ([33.1.1. Connection Strings](https://www.postgresql.org/docs/10/libpq-connect.html#LIBPQ-CONNSTRING)).
 
 For information on the `type_map` and `conversions` arguments, see [Type Conversions](@ref typeconv).
 
@@ -262,7 +262,7 @@ end
 
 Get the PostgreSQL version of the server.
 
-See [33.2. Connection Status Functions](https://www.postgresql.org/docs/10/static/libpq-status.html#LIBPQ-PQSERVERVERSION)
+See [33.2. Connection Status Functions](https://www.postgresql.org/docs/10/libpq-status.html#LIBPQ-PQSERVERVERSION)
 for information on the integer returned by `PQserverVersion` that is parsed by this
 function.
 
@@ -347,7 +347,7 @@ end
     encoding(jl_conn::Connection) -> String
 
 Return the client encoding name for the current connection (see
-[Table 23.1. PostgreSQL Character Sets](https://www.postgresql.org/docs/10/static/multibyte.html#CHARSET-TABLE)
+[Table 23.1. PostgreSQL Character Sets](https://www.postgresql.org/docs/10/multibyte.html#CHARSET-TABLE)
 for possible values).
 
 Currently all Julia connections are set to use `UTF8` as this makes conversion to and from
@@ -369,7 +369,7 @@ end
     set_encoding!(jl_conn::Connection, encoding::String)
 
 Set the client encoding for the current connection (see
-[Table 23.1. PostgreSQL Character Sets](https://www.postgresql.org/docs/10/static/multibyte.html#CHARSET-TABLE)
+[Table 23.1. PostgreSQL Character Sets](https://www.postgresql.org/docs/10/multibyte.html#CHARSET-TABLE)
 for possible values).
 
 Currently all Julia connections are set to use `UTF8` as this makes conversion to and from
@@ -428,7 +428,7 @@ status(jl_conn::Connection) = libpq_c.PQstatus(jl_conn.conn)
     transaction_status(jl_conn::Connection) -> libpq_c.PGTransactionStatusType
 
 Return the PostgreSQL database server's current in-transaction status for the connection.
-See [](https://www.postgresql.org/docs/10/static/libpq-status.html#LIBPQ-PQTRANSACTIONSTATUS)
+See [](https://www.postgresql.org/docs/10/libpq-status.html#LIBPQ-PQTRANSACTIONSTATUS)
 for information on the meaning of the possible return values.
 """
 transaction_status(jl_conn::Connection) = libpq_c.PQtransactionStatus(jl_conn.conn)
@@ -437,7 +437,7 @@ transaction_status(jl_conn::Connection) = libpq_c.PQtransactionStatus(jl_conn.co
     close(jl_conn::Connection)
 
 Close the PostgreSQL database connection and free the memory used by the `PGconn` object.
-This function calls [`PQfinish`](https://www.postgresql.org/docs/10/static/libpq-connect.html#LIBPQ-PQFINISH),
+This function calls [`PQfinish`](https://www.postgresql.org/docs/10/libpq-connect.html#LIBPQ-PQFINISH),
 but only if `jl_conn.closed` is `false`, to avoid a double-free.
 """
 function Base.close(jl_conn::Connection)
@@ -1080,7 +1080,7 @@ The statement is given an generated unique name using [`unique_id`](@ref).
 !!! note
 
     Currently the statement is not explicitly deallocated, but it is deallocated at the end
-    of session per the [PostgreSQL documentation on DEALLOCATE](https://www.postgresql.org/docs/10/static/sql-deallocate.html).
+    of session per the [PostgreSQL documentation on DEALLOCATE](https://www.postgresql.org/docs/10/sql-deallocate.html).
 """
 function prepare(jl_conn::Connection, query::AbstractString)
     uid = unique_id(jl_conn, "stmt")

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -4,7 +4,7 @@
 Create a `CopyIn` query instance which can be executed to send data to PostgreSQL via a
 `COPY <table_name> FROM STDIN` query.
 
-`query` must be a `COPY FROM STDIN` query as described in the [PostgreSQL documentation](https://www.postgresql.org/docs/10/static/sql-copy.html).
+`query` must be a `COPY FROM STDIN` query as described in the [PostgreSQL documentation](https://www.postgresql.org/docs/10/sql-copy.html).
 `COPY FROM` queries which use a file or `PROGRAM` source can instead use the standard
 [`execute`](@ref) query interface.
 


### PR DESCRIPTION
Avoids hitting redirects.

The 405 from codecov means codecov doesn't support `HEAD`. It also doesn't support `OPTIONS`. I will make a PR to Documenter that falls back to `GET` if `HEAD` fails with a 405. 