### PR TITLE
Support arrays as parameters

### DIFF
--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -903,17 +903,31 @@ string_parameters(parameters::AbstractVector{<:Parameter}) = parameters
 string_parameters(parameters::Tuple) = string_parameters(collect(parameters))
 
 # vector which can't contain missing
-string_parameters(parameters::AbstractVector) = map(string, parameters)
+string_parameters(parameters::AbstractVector) = map(string_parameter, parameters)
 
 # vector which might contain missings
 function string_parameters(parameters::AbstractVector{>:Missing})
     collect(
         Union{String, Missing},
         imap(parameters) do parameter
-            ismissing(parameter) ? missing : string(parameter)
+            ismissing(parameter) ? missing : string_parameter(parameter)
         end
     )
 end
+
+string_parameter(parameter) = string(parameter)
+
+function string_parameter(parameter::AbstractVector)
+    io = IOBuffer()
+    print(io, "{")
+    join(io, (_array_element(el) for el in parameter), ",")
+    print(io, "}")
+    String(take!(io))
+end
+
+_array_element(el::AbstractString) = "\"$el\""
+_array_element(el::Missing) = "NULL"
+_array_element(el) = string_parameter(el)
 
 """
     parameter_pointers(parameters::AbstractVector{<:Parameter}) -> Vector{Ptr{UInt8}}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -776,6 +776,40 @@ end
             end
         end
 
+        @testset "Parameters" begin
+            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+
+            result = execute(conn, "SELECT 'foo' = ANY(\$1)", [["bar", "foo"]])
+            @test first(first(Tables.columns(result)))
+            close(result)
+
+            result = execute(conn, "SELECT 'foo' = ANY(\$1)", (["bar", "foo"],))
+            @test first(first(Tables.columns(result)))
+            close(result)
+
+            result = execute(conn, "SELECT 'foo' = ANY(\$1)", [Any["bar", "foo"]])
+            @test first(first(Tables.columns(result)))
+            close(result)
+
+            result = execute(conn, "SELECT 'foo' = ANY(\$1)", Any[Any["bar", "foo"]])
+            @test first(first(Tables.columns(result)))
+            close(result)
+
+            result = execute(conn, "SELECT 'foo' = ANY(\$1)", [["bar", "foobar"]])
+            @test !first(first(Tables.columns(result)))
+            close(result)
+
+            result = execute(conn, "SELECT ARRAY[1, 2] = \$1", [[1, 2]])
+            @test first(first(Tables.columns(result)))
+            close(result)
+
+            result = execute(conn, "SELECT ARRAY[1, 2] = \$1", Any[Any[1, 2]])
+            @test first(first(Tables.columns(result)))
+            close(result)
+
+            close(conn)
+        end
+
         @testset "Query Errors" begin
             @testset "Syntax Errors" begin
                 conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)


### PR DESCRIPTION
Added functionality for writing to PostgreSQL's [array literal syntax](https://www.postgresql.org/docs/10/arrays.html#ARRAYS-INPUT) to implement this.