### PR TITLE
Remove use of Tables.istable

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -39,9 +39,8 @@ end
 
 # sink
 function load!(table::T, connection::Connection, query::AbstractString) where {T}
-    Tables.istable(T) || throw(ArgumentError("$T doesn't support the required Tables.jl interface"))
-    stmt = prepare(connection, query)
     rows = Tables.rows(table)
+    stmt = prepare(connection, query)
     state = iterate(rows)
     state === nothing && return
     st, row = state


### PR DESCRIPTION
@iamed2, by eagerly calling `Tables.rows(t)`, there are additional objects that can be used as valid "tables"; `Tables.rows` itself will throw an error if the input is indeed not a valid table. 