### PR TITLE
Use the local time zone instead of UTC as connection default

### DIFF
--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -78,7 +78,7 @@ show_option(num::Real) = num
 const CONNECTION_OPTION_DEFAULTS = Dict{String, String}(
     "DateStyle" => "ISO,YMD",
     "IntervalStyle" => "iso_8601",
-    "TimeZone" => "UTC",
+    "TimeZone" => string(localzone()),
 )
 
 function _connection_parameter_dict(;

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -191,9 +191,9 @@ The default connection options are:
 * "TimeZone" = "UTC", or the `PGTZ` environment variable, or server timezone if
 `PGTZ` is set but empty
 
-Note that these default connection options may be different than the defaults in
-used by the server, and are used in `psql`. To use the defaults provided by the
-server, use `options = Dict{String, String}()`.
+Note that these default connection options may be different than the defaults
+used by the server, which are the defaults used by `psql`. To use the defaults
+provided by the server, use `options = Dict{String, String}()`.
 """
 function Connection(
     str::AbstractString;

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -75,10 +75,12 @@ show_option(bool::Bool) = ifelse(bool, 't', 'f')
 show_option(num::Real) = num
 
 # values containing spaces may not work correctly on PostgreSQL versions before 9.6
+maybe_pgtz_env = get(ENV, "PGTZ", nothing)
+maybe_timezone_arg = ifelse(maybe_pgtz_env == nothing, (), ("TimeZone" => maybe_pgtz_env,))
 const CONNECTION_OPTION_DEFAULTS = Dict{String, String}(
     "DateStyle" => "ISO,YMD",
     "IntervalStyle" => "iso_8601",
-    "TimeZone" => string(localzone()),
+    maybe_timezone_arg...
 )
 
 function _connection_parameter_dict(;

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -188,7 +188,8 @@ For a list of available options for the `options` argument, see
 The default connection options are:
 * "DateStyle" =  "ISO,YMD"
 * "IntervalStyle" = "iso_8601"
-* "TimeZone" = "UTC", or the `PGTZ` environment variable, if set
+* "TimeZone" = "UTC", or the `PGTZ` environment variable, or server timezone if
+`PGTZ` is set but empty
 
 Note that these default connection options may be different than the defaults in
 used by the server, and are used in `psql`. To use the defaults provided by the

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -75,10 +75,12 @@ show_option(bool::Bool) = ifelse(bool, 't', 'f')
 show_option(num::Real) = num
 
 # values containing spaces may not work correctly on PostgreSQL versions before 9.6
+env_pgtz = get(ENV, "PGTZ", "UTC")
+default_tz = ifelse(isempty(env_pgtz), "UTC", env_pgtz)
 const CONNECTION_OPTION_DEFAULTS = Dict{String, String}(
     "DateStyle" => "ISO,YMD",
     "IntervalStyle" => "iso_8601",
-    "TimeZone" => get(ENV, "PGTZ", "UTC"),
+    "TimeZone" => default_tz,
 )
 
 function _connection_parameter_dict(;
@@ -186,7 +188,7 @@ For a list of available options for the `options` argument, see
 The default connection options are:
 * "DateStyle" =  "ISO,YMD"
 * "IntervalStyle" = "iso_8601"
-* "TimeZone" => "UTC", or the `PGTZ` environment variable, if set
+* "TimeZone" = "UTC", or the `PGTZ` environment variable, if set
 
 Note that these default connection options may be different than the defaults in
 used by the server, and are used in `psql`. To use the defaults provided by the

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -75,12 +75,10 @@ show_option(bool::Bool) = ifelse(bool, 't', 'f')
 show_option(num::Real) = num
 
 # values containing spaces may not work correctly on PostgreSQL versions before 9.6
-maybe_pgtz_env = get(ENV, "PGTZ", nothing)
-maybe_timezone_arg = ifelse(maybe_pgtz_env == nothing, (), ("TimeZone" => maybe_pgtz_env,))
 const CONNECTION_OPTION_DEFAULTS = Dict{String, String}(
     "DateStyle" => "ISO,YMD",
     "IntervalStyle" => "iso_8601",
-    maybe_timezone_arg...
+    "TimeZone" => get(ENV, "PGTZ", "UTC"),
 )
 
 function _connection_parameter_dict(;
@@ -178,9 +176,21 @@ documentation ([33.1.1. Connection Strings](https://www.postgresql.org/docs/10/l
 
 For information on the `type_map` and `conversions` arguments, see [Type Conversions](@ref typeconv).
 
-For a list of available options for the `options` argument, see [Server Configuration](https://www.postgresql.org/docs/10/runtime-config.html).
-
 See [`handle_new_connection`](@ref) for information on the `throw_error` argument.
+
+# Connection Options
+
+For a list of available options for the `options` argument, see
+[Server Configuration](https://www.postgresql.org/docs/10/runtime-config.html).
+
+The default connection options are:
+* "DateStyle" =  "ISO,YMD"
+* "IntervalStyle" = "iso_8601"
+* "TimeZone" => "UTC", or the `PGTZ` environment variable, if set
+
+Note that these default connection options may be different than the defaults in
+used by the server, and are used in `psql`. To use the defaults provided by the
+server, use `options = Dict{String, String}()`.
 """
 function Connection(
     str::AbstractString;

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -76,11 +76,11 @@ show_option(num::Real) = num
 
 # values containing spaces may not work correctly on PostgreSQL versions before 9.6
 env_pgtz = get(ENV, "PGTZ", "UTC")
-default_tz = ifelse(isempty(env_pgtz), "UTC", env_pgtz)
+maybe_tz_arg = ifelse(isempty(env_pgtz), (), ("TimeZone" => env_pgtz,))
 const CONNECTION_OPTION_DEFAULTS = Dict{String, String}(
     "DateStyle" => "ISO,YMD",
     "IntervalStyle" => "iso_8601",
-    "TimeZone" => default_tz,
+    maybe_tz_arg...
 )
 
 function _connection_parameter_dict(;


### PR DESCRIPTION
When working with timestamptz and similar time-zone aware types in postgres,
the connection time zone determines how the result will be displayed. Instead of
UTC, I believe that the local system time zone may be a better default. I
believe this is what psql does.