### PR TITLE
Allow concrete array types to be specified with column_types

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -326,8 +326,10 @@ for pq_eltype in ("int2", "int4", "int8", "float4", "float8", "oid", "numeric")
     _DEFAULT_TYPE_MAP[array_oid] = AbstractArray{jl_missingtype}
 
     for jl_eltype in (jl_type, jl_missingtype)
-        @eval function Base.parse(::Type{<:AbstractArray{$jl_eltype}}, pqv::PQValue{$array_oid})
-            parse_numeric_array($jl_eltype, string_view(pqv))
+        @eval function Base.parse(
+            ::Type{A}, pqv::PQValue{$array_oid}
+        ) where A <: AbstractArray{$jl_eltype}
+            parse_numeric_array($jl_eltype, string_view(pqv))::A
         end
     end
 end

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -326,7 +326,7 @@ for pq_eltype in ("int2", "int4", "int8", "float4", "float8", "oid", "numeric")
     _DEFAULT_TYPE_MAP[array_oid] = AbstractArray{jl_missingtype}
 
     for jl_eltype in (jl_type, jl_missingtype)
-        @eval function Base.parse(::Type{AbstractArray{$jl_eltype}}, pqv::PQValue{$array_oid})
+        @eval function Base.parse(::Type{<:AbstractArray{$jl_eltype}}, pqv::PQValue{$array_oid})
             parse_numeric_array($jl_eltype, string_view(pqv))
         end
     end


### PR DESCRIPTION
Previously, it was not possible to set a column type to something like
`Vector{Int32}`, and one would instead have to specify `AbstractArray{Int32}`.
By changing the parse method for arrays to accept all subtypes of
`AbstractArray`, it is now possible to specify `Vector{Int32}`, or any other
concrete type of array, as a column type.