### PR TITLE
Allow forcing server time zone and acknowledge the existence of PGTZ env var

### DIFF
--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -88,11 +88,15 @@ function _connection_parameter_dict(;
     application_name::String="LibPQ.jl",
     connection_options::Dict{String, String}=Dict{String, String}(),
 )
+    keep_option((k, v)) = !(k == "TimeZone" && v == "")
+
     Dict{String, String}(
         "client_encoding" => client_encoding,
         "application_name" => application_name,
         "options" => join(
-            ("-c $k=$(show_option(v))" for (k, v) in connection_options if !(k == "TimeZone" && v == "")),
+            imap(Iterators.filter(keep_option, connection_options)) do (k, v)
+                "-c $k=$(show_option(v))"
+            end,
             " ",
         ),
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -400,6 +400,8 @@ end
             default_tz = LibPQ.DEFAULT_CLIENT_TIME_ZONE[]
             try
                 LibPQ.DEFAULT_CLIENT_TIME_ZONE[] = "America/Scoresbysund"
+                LibPQ.CONNECTION_OPTION_DEFAULTS["TimeZone"] = LibPQ.DEFAULT_CLIENT_TIME_ZONE[]
+                merge!(LibPQ.CONNECTION_PARAMETER_DEFAULTS, LibPQ._connection_parameter_dict(connection_options=LibPQ.CONNECTION_OPTION_DEFAULTS))
                 withenv("PGTZ" => nothing) do  # unset
                     LibPQ.Connection(
                         "dbname=postgres user=$DATABASE_USER"; throw_error=true
@@ -480,6 +482,8 @@ end
                 end
             finally
                 LibPQ.DEFAULT_CLIENT_TIME_ZONE[] = default_tz
+                LibPQ.CONNECTION_OPTION_DEFAULTS["TimeZone"] = LibPQ.DEFAULT_CLIENT_TIME_ZONE[]
+                merge!(LibPQ.CONNECTION_PARAMETER_DEFAULTS, LibPQ._connection_parameter_dict(connection_options=LibPQ.CONNECTION_OPTION_DEFAULTS))
             end
         end
 


### PR DESCRIPTION
Now you can force the server time zone to be used by passing `""` as the `TimeZone` option. This is normally an invalid value. The `PGTZ` environment variable is used internally by `libpq` and will take precedence.