### PR TITLE
Add a lot more indexing and iteration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,8 +24,8 @@ IterTools = "1"
 LayerDicts = "1"
 Memento = "0.10, 0.11, 0.12"
 OffsetArrays = "0.9.1, 0.10, 0.11"
+Tables = "0.2"
 TimeZones = "0.8, 0.9"
-Tables = "=0.2.1"
 julia = "1"
 
 [extras]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -58,10 +58,10 @@ uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.7.0"
 
 [[Documenter]]
-deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "Pkg", "REPL", "Random", "Test", "Unicode"]
-git-tree-sha1 = "13a6d15102410d8e70146533b759fc48d844a1d0"
+deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Unicode"]
+git-tree-sha1 = "38509269fc99a9bc450fdb9e17e805021f3e5b1b"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.22.3"
+version = "0.22.4"
 
 [[EzXML]]
 deps = ["BinaryProvider", "Libdl", "Pkg", "Printf", "Test"]
@@ -103,10 +103,10 @@ version = "1.0.0"
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[LibPQ]]
-deps = ["BinaryProvider", "Dates", "Decimals", "Distributed", "DocStringExtensions", "IterTools", "LayerDicts", "Libdl", "Memento", "OffsetArrays", "Tables", "TimeZones"]
+deps = ["BinaryProvider", "Dates", "Decimals", "DocStringExtensions", "IterTools", "LayerDicts", "Libdl", "Memento", "OffsetArrays", "Tables", "TimeZones"]
 path = ".."
 uuid = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
-version = "0.9.0"
+version = "0.9.1"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -129,10 +129,10 @@ uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 version = "0.12.1"
 
 [[Missings]]
-deps = ["Dates", "InteractiveUtils", "SparseArrays", "Test"]
-git-tree-sha1 = "d1d2585677f2bd93a97cfeb8faa7a0de0f982042"
+deps = ["SparseArrays", "Test"]
+git-tree-sha1 = "f0719736664b4358aa9ec173077d4285775f8007"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.4.0"
+version = "0.4.1"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -142,12 +142,6 @@ deps = ["Compat", "Dates"]
 git-tree-sha1 = "4bf69aaf823b119b034e091e16b18311aa191663"
 uuid = "78c3b35d-d492-501b-9361-3d52fe80e533"
 version = "0.5.7"
-
-[[Nullables]]
-deps = ["Compat"]
-git-tree-sha1 = "ae1a63457e14554df2159b0b028f48536125092d"
-uuid = "4d1e1d77-625e-5b40-9113-a560ec7a8ecd"
-version = "0.0.8"
 
 [[OffsetArrays]]
 deps = ["DelimitedFiles"]
@@ -229,10 +223,10 @@ uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 version = "0.30.0"
 
 [[Syslogs]]
-deps = ["Compat", "Nullables"]
-git-tree-sha1 = "d3e512a044cc8873c741d88758f8e1888c7c47d3"
+deps = ["Printf", "Sockets"]
+git-tree-sha1 = "46badfcc7c6e74535cc7d833a91f4ac4f805f86d"
 uuid = "cea106d9-e007-5e6c-ad93-58fe2094e9c4"
-version = "0.2.0"
+version = "0.3.0"
 
 [[TableTraits]]
 deps = ["IteratorInterfaceExtensions"]
@@ -242,19 +236,19 @@ version = "1.0.0"
 
 [[Tables]]
 deps = ["IteratorInterfaceExtensions", "LinearAlgebra", "Requires", "TableTraits", "Test"]
-git-tree-sha1 = "9e748316f5aa7b7753c90de612ef98fe8b0ea297"
+git-tree-sha1 = "c5d784c61e9d243a5a6a8458d19f535b70bdedeb"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "0.2.1"
+version = "0.2.4"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TimeZones]]
-deps = ["Dates", "EzXML", "Mocking", "Printf", "Serialization", "Test", "Unicode"]
-git-tree-sha1 = "fdf5d2136d16498cb67d648cedd33b83c599e0c5"
+deps = ["Dates", "EzXML", "Mocking", "Printf", "Serialization", "Unicode"]
+git-tree-sha1 = "859bfc1832ea52e413c96fa5c92130516db62bdb"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "0.9.0"
+version = "0.9.1"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -30,6 +30,15 @@ function PQValue(jl_result::Result, row::Integer, col::Integer)
 end
 
 """
+    isnull(jl_result::Result, row::Integer, col::Integer) -> Bool
+
+Return whether the result value at the specified row and column (1-indexed) is `NULL`.
+"""
+function isnull(jl_result::Result, row::Integer, col::Integer)
+    return libpq_c.PQgetisnull(jl_result.result, row - 1, col - 1) == 1
+end
+
+"""
     num_bytes(pqv::PQValue) -> Cint
 
 The length in bytes of the `PQValue`'s corresponding data.

--- a/src/results.jl
+++ b/src/results.jl
@@ -22,7 +22,7 @@ mutable struct Result
     function Result(
         result::Ptr{libpq_c.PGresult},
         jl_conn::Connection;
-        column_types::AbstractDict=ColumnTypeMap(),
+        column_types::Union{AbstractDict, AbstractVector}=ColumnTypeMap(),
         type_map::AbstractDict=PQTypeMap(),
         conversions::AbstractDict=PQConversions(),
         not_null=false,
@@ -30,7 +30,7 @@ mutable struct Result
         jl_result = new(result, Atomic{Bool}(result == C_NULL))
 
         column_type_map = ColumnTypeMap()
-        for (k, v) in column_types
+        for (k, v) in pairs(column_types)
             column_type_map[column_number(jl_result, k)] = v
         end
 

--- a/src/results.jl
+++ b/src/results.jl
@@ -408,7 +408,7 @@ end
 Return the index of the column if it is valid, or error.
 """
 function column_number(jl_result::Result, column_idx::Integer)::Int
-    if !checkindex(Bool, Base.OneTo(num_columns(jl_result)), column_idx)
+    @boundscheck if !checkindex(Bool, Base.OneTo(num_columns(jl_result)), column_idx)
         throw(BoundsError(column_names(jl_result), column_idx))
     end
 

--- a/src/results.jl
+++ b/src/results.jl
@@ -408,7 +408,7 @@ end
 Return the index of the column if it is valid, or error.
 """
 function column_number(jl_result::Result, column_idx::Integer)::Int
-    if !checkindex(Bool, 1:num_columns(jl_result), column_idx)
+    if !checkindex(Bool, Base.OneTo(num_columns(jl_result)), column_idx)
         throw(BoundsError(column_names(jl_result), column_idx))
     end
 

--- a/src/results.jl
+++ b/src/results.jl
@@ -428,3 +428,20 @@ column_oids(jl_result::Result) = jl_result.column_oids
 Return the corresponding Julia types for each column in the result.
 """
 column_types(jl_result::Result) = jl_result.column_types
+
+"""
+    getindex(jl_result::Result, row::Integer, col::Integer) -> Union{_, Missing}
+
+Return the parsed value of the result at the row and column specified (1-indexed).
+The returned value will be `missing` if `NULL`, or will be of the type specified in
+[`column_types`](@ref).
+"""
+function Base.getindex(jl_result::Result, row::Integer, col::Integer)
+    if isnull(jl_result, row, col)
+        return missing
+    else
+        oid = column_oids(jl_result)[col]
+        T = column_types(jl_result)[col]
+        return jl_result.column_funcs[col](PQValue{oid}(jl_result, row, col))::T
+    end
+end

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -87,7 +87,7 @@ function Tables.schema(cs::Columns)
 end
 
 function Column(jl_result::Result, col::Integer, name=Symbol(column_name(jl_result, col)))
-    if !checkindex(Bool, Base.OneTo(num_columns(jl_result)), col)
+    @boundscheck if !checkindex(Bool, Base.OneTo(num_columns(jl_result)), col)
         throw(BoundsError(Columns(jl_result)), col)
     end
 

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -87,7 +87,7 @@ function Tables.schema(cs::Columns)
 end
 
 function Column(jl_result::Result, col::Integer, name=Symbol(column_name(jl_result, col)))
-    if !checkindex(Bool, 1:num_columns(jl_result), col)
+    if !checkindex(Bool, Base.OneTo(num_columns(jl_result)), col)
         throw(BoundsError(Columns(jl_result)), col)
     end
 

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,20 +1,23 @@
 Tables.istable(::Type{<:Result}) = true
+
+# Rows
+
 Tables.rowaccess(::Type{<:Result}) = true
 Tables.rows(jl_result::Result) = jl_result
 
 Base.eltype(jl_result::Result) = Row
 Base.length(jl_result::Result) = num_rows(jl_result)
 
+function Base.iterate(jl_result::Result, (len, row)=(length(jl_result), 1))
+    row > len && return nothing
+    return Row(jl_result, row), (len, row + 1)
+end
+
 function Tables.schema(jl_result::Result)
     types = map(jl_result.not_null, column_types(jl_result)) do not_null, col_type
         not_null ? col_type : Union{col_type, Missing}
     end
     return Tables.Schema(map(Symbol, column_names(jl_result)), types)
-end
-
-function Base.iterate(jl_result::Result, (len, row)=(length(jl_result), 1))
-    row > len && return nothing
-    return Row(jl_result, row), (len, row + 1)
 end
 
 struct Row
@@ -25,7 +28,7 @@ end
 result(pqrow::Row) = getfield(pqrow, :result)
 row_number(pqrow::Row) = getfield(pqrow, :row)
 
-Base.propertynames(pqrow::Row) = column_names(result(pqrow))
+Base.propertynames(pqrow::Row) = map(Symbol, column_names(result(pqrow)))
 
 function Base.getproperty(pqrow::Row, name::Symbol)
     jl_result = result(pqrow)
@@ -45,6 +48,79 @@ function Base.iterate(pqrow::Row, (len, col)=(length(pqrow), 1))
     col > len && return nothing
     return (result(pqrow)[row_number(pqrow), col], (len, col + 1))
 end
+
+# Columns
+
+struct Column{T} <: AbstractVector{T}
+    result::Result
+    col::Int
+    col_name::Symbol
+    oid::Oid
+    not_null::Bool
+    typ::Type
+    func::Base.Callable
+end
+
+struct Columns <: AbstractVector{Column}
+    result::Result
+end
+
+result(cs::Columns) = getfield(cs, :result)
+
+Base.propertynames(cs::Columns) = map(Symbol, column_names(result(cs)))
+
+Base.getproperty(cs::Columns, name::Symbol) = Column(result(cs), name)
+Base.getindex(cs::Columns, col::Integer) = Column(result(cs), col)
+Base.IndexStyle(::Type{Columns}) = IndexLinear()
+Base.length(cs::Columns) = num_columns(result(cs))
+Base.size(cs::Columns) = (length(cs),)
+
+Tables.columnaccess(::Type{<:Result}) = true
+Tables.columns(jl_result::Result) = Columns(jl_result)
+
+function Tables.schema(cs::Columns)
+    jl_result = result(cs)
+    types = map(jl_result.not_null, column_types(jl_result)) do not_null, col_type
+        not_null ? col_type : Union{col_type, Missing}
+    end
+    return Tables.Schema(map(Symbol, column_names(jl_result)), types)
+end
+
+function Column(jl_result::Result, col::Integer, name=Symbol(column_name(jl_result, col)))
+    if !checkindex(Bool, 1:num_columns(jl_result), col)
+        throw(BoundsError(Columns(jl_result)), col)
+    end
+
+    oid = column_oids(jl_result)[col]
+    typ = column_types(jl_result)[col]
+    func = jl_result.column_funcs[col]
+    not_null = jl_result.not_null[col]
+    element_type = not_null ? typ : Union{typ, Missing}
+    return Column{element_type}(jl_result, col, name, oid, not_null, typ, func)
+end
+
+function Column(jl_result::Result, name::Symbol, col=column_number(jl_result, name))
+    return Column(jl_result, col, name)
+end
+
+result(c::Column) = getfield(c, :result)
+column_number(c::Column) = getfield(c, :col)
+column_name(c::Column) = getfield(c, :col_name)
+
+function Base.getindex(c::Column{T}, row::Integer)::T where T
+    jl_result = result(c)
+    col = column_number(c)
+    if isnull(jl_result, row, col)
+        return missing
+    else
+        return c.func(PQValue{c.oid}(jl_result, row, col))::c.typ
+    end
+end
+
+Base.IndexStyle(::Type{<:Column}) = IndexLinear()
+Base.length(c::Column) = num_rows(result(c))
+Base.size(c::Column) = (length(c),)
+
 
 """
     LibPQ.load!(table, connection::LibPQ.Connection, query) -> LibPQ.Statement
@@ -71,7 +147,7 @@ function load!(table::T, connection::Connection, query::AbstractString) where {T
     rows = Tables.rows(table)
     stmt = prepare(connection, query)
     state = iterate(rows)
-    state === nothing && return
+    state === nothing && return stmt
     row, st = state
     names = propertynames(row)
     sch = Tables.Schema(names, nothing)

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -25,7 +25,7 @@ end
 result(pqrow::Row) = getfield(pqrow, :result)
 row_number(pqrow::Row) = getfield(pqrow, :row)
 
-Base.propertynames(r::Row) = column_names(getfield(r, :result))
+Base.propertynames(pqrow::Row) = column_names(result(pqrow))
 
 function Base.getproperty(pqrow::Row, name::Symbol)
     jl_result = result(pqrow)

--- a/src/typemaps.jl
+++ b/src/typemaps.jl
@@ -214,9 +214,19 @@ end
 
 PQConversions(func_map::PQConversions) = func_map
 function PQConversions(func_map::AbstractDict{Tuple{Oid, Type}, Base.Callable})
-    return Dict{Tuple{Oid, Type}, Base.Callable}(func_map)
+    return PQConversions(Dict{Tuple{Oid, Type}, Base.Callable}(func_map))
 end
 PQConversions() = PQConversions(Dict{Tuple{Oid, Type}, Base.Callable}())
+
+function PQConversions(user_map::AbstractDict)
+    func_map = PQConversions()
+
+    for (k, v) in user_map
+        func_map[k] = v
+    end
+
+    return func_map
+end
 
 """
     Base.getindex(cmap::PQConversions, oid_typ::Tuple{Any, Type}) -> Base.Callable

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -937,31 +937,31 @@ end
             conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
 
             result = execute(conn, "SELECT 'foo' = ANY(\$1)", [["bar", "foo"]])
-            @test first(first(Tables.columns(result)))
+            @test first(first(result))
             close(result)
 
             result = execute(conn, "SELECT 'foo' = ANY(\$1)", (["bar", "foo"],))
-            @test first(first(Tables.columns(result)))
+            @test first(first(result))
             close(result)
 
             result = execute(conn, "SELECT 'foo' = ANY(\$1)", [Any["bar", "foo"]])
-            @test first(first(Tables.columns(result)))
+            @test first(first(result))
             close(result)
 
             result = execute(conn, "SELECT 'foo' = ANY(\$1)", Any[Any["bar", "foo"]])
-            @test first(first(Tables.columns(result)))
+            @test first(first(result))
             close(result)
 
             result = execute(conn, "SELECT 'foo' = ANY(\$1)", [["bar", "foobar"]])
-            @test !first(first(Tables.columns(result)))
+            @test !first(first(result))
             close(result)
 
             result = execute(conn, "SELECT ARRAY[1, 2] = \$1", [[1, 2]])
-            @test first(first(Tables.columns(result)))
+            @test first(first(result))
             close(result)
 
             result = execute(conn, "SELECT ARRAY[1, 2] = \$1", Any[Any[1, 2]])
-            @test first(first(Tables.columns(result)))
+            @test first(first(result))
             close(result)
 
             close(conn)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -835,7 +835,7 @@ end
 
                 result = execute(
                     conn,
-                    "SELECT 'deadbeef';",
+                    "SELECT 'deadbeef'::text;",  # unknown type on PostgreSQL < 10
                     type_map=Dict(:text=>Vector{UInt8}),
                     conversions=Dict((:text, Vector{UInt8})=>hex2bytes∘LibPQ.string_view),
                 )
@@ -843,7 +843,7 @@ end
 
                 result = execute(
                     conn,
-                    "SELECT '0xdeadbeef';",
+                    "SELECT '0xdeadbeef'::text;",
                     type_map=Dict(:text=>String),
                     column_types=[UInt32],
                 )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -208,13 +208,12 @@ end
         @test data[:yes_nulls][1] == "bar"
         @test data[:yes_nulls][2] === missing
 
-        close(result)
-
         stmt = LibPQ.load!(
             data,
             conn,
             "INSERT INTO libpqjl_test (no_nulls, yes_nulls) VALUES (\$1, \$2);",
         )
+
         @test_throws ArgumentError num_affected_rows(stmt.description)
         @test num_params(stmt) == 2
         @test num_columns(stmt) == 0  # an insert has no results
@@ -672,7 +671,7 @@ end
             @test LibPQ.num_columns(result) == 1
             @test LibPQ.num_rows(result) == 1
 
-            @test_throws MethodError columntable(result)
+            @test_throws MethodError columntable(result)[1][1]
 
             close(result)
 
@@ -681,7 +680,7 @@ end
             @test LibPQ.num_columns(result) == 1
             @test LibPQ.num_rows(result) == 1
 
-            @test_throws MethodError columntable(result)
+            @test_throws MethodError columntable(result)[1][1]
 
             close(result)
 
@@ -701,10 +700,10 @@ end
             data = columntable(result)
 
             @test data[:no_nulls] == ["foo", "baz"]
-            @test data[:no_nulls] isa Vector{String}
+            @test data[:no_nulls] isa AbstractVector{String}
             @test data[:yes_nulls][1] == "bar"
             @test data[:yes_nulls][2] === missing
-            @test data[:yes_nulls] isa Vector{Union{String, Missing}}
+            @test data[:yes_nulls] isa AbstractVector{Union{String, Missing}}
 
             close(result)
 
@@ -724,10 +723,10 @@ end
             data = columntable(result)
 
             @test data[:no_nulls] == ["foo", "baz"]
-            @test data[:no_nulls] isa Vector{Union{String, Missing}}
+            @test data[:no_nulls] isa AbstractVector{Union{String, Missing}}
             @test data[:yes_nulls][1] == "bar"
             @test data[:yes_nulls][2] === missing
-            @test data[:yes_nulls] isa Vector{Union{String, Missing}}
+            @test data[:yes_nulls] isa AbstractVector{Union{String, Missing}}
 
             close(result)
         end
@@ -749,15 +748,45 @@ end
             rt = Tables.rows(result)
             data = collect(rt)
             @test data[1].no_nulls == "foo"
+            @test data[1][1] == "foo"
             @test data[2].no_nulls == "baz"
+            @test data[2][1] == "baz"
             @test data[1].yes_nulls == "bar"
+            @test data[1][2] == "bar"
             @test data[2].yes_nulls === missing
+            @test data[2][2] === missing
 
+            # columns
             ct = Tables.columns(result)
             no_nulls = collect(ct.no_nulls)
             @test no_nulls == ["foo", "baz"]
             yes_nulls = collect(ct.yes_nulls)
             @test isequal(yes_nulls, ["bar", missing])
+
+            collected = map(collect, Tables.columns(result))
+            @test collected isa AbstractVector{<:AbstractVector{Union{String, Missing}}}
+            @test collected isa Vector{Vector{Union{String, Missing}}}
+            @test collected[1] == ["foo", "baz"]
+            @test isequal(collected[2], ["bar", missing])
+
+            close(result)
+            close(conn)
+        end
+
+        @testset "Duplicate names" begin
+            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+
+            result = execute(conn, "SELECT 1 AS col, 2 AS col;", not_null=true, throw_error=true)
+            columns = Tables.columns(result)
+            @test columns[1] == [1]
+            @test columns[2] == [2]
+
+            row = first(Tables.rows(result))
+            @test row[1] == 1
+            @test row[2] == 2
+
+            close(result)
+            close(conn)
         end
 
         @testset "Type Conversions" begin
@@ -1050,7 +1079,7 @@ end
                 [16],
             )
             close(result)
-            @test_throws ErrorException columntable(result)
+            @test_throws BoundsError columntable(result)
 
             close(conn)
             @test !isopen(conn)


### PR DESCRIPTION
Tables 0.2.2 broke columntable for some reason so I fleshed out the backend to include a Columns type to act as Tables.columns. I also implemented indexing and iteration for more structures (including indexing for `Result`), sometimes using `AbstractVector`.