### PR TITLE
Add asynchronous execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /deps/deps.jl
 /deps/usr/
 /deps/build.log
+/Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ julia:
   - 1.0
 env:
   matrix:
+    - POSTGRESQL_VERSION=12
     - POSTGRESQL_VERSION=11
     - POSTGRESQL_VERSION=10
     - POSTGRESQL_VERSION=9.6
@@ -22,6 +23,7 @@ matrix:
   fast_finish: true
   include:
     - julia: 1.1
+    - julia: 1.2
     - julia: nightly
     - os: osx
       env:

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,14 @@
 name = "LibPQ"
 uuid = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
 license = "MIT"
-version = "0.9.1"
+version = "0.10.0"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Decimals = "abce61dc-4473-55a0-ba07-351d65e31d42"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 LayerDicts = "6f188dcb-512c-564b-bc01-e0f76e72f166"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ LibPQ.jl is a Julia wrapper for the PostgreSQL `libpq` C library.
   * UTF-8 client encoding
 * Queries
   * Create and execute queries with or without parameters
+  * Execute queries asynchronously
   * Stream results using [Tables](https://github.com/JuliaData/Tables.jl)
   * Configurably convert a variety of PostgreSQL types to corresponding Julia types (see the **Type Conversions** section of the docs)
 * Prepared Statements

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
   matrix:
   - julia_version: 1.0
   - julia_version: 1.1
+  - julia_version: 1.2
 
 platform:
   - x86 # 32-bit

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,6 +20,12 @@ data = columntable(result)
 result = execute(conn, "SELECT typname FROM pg_type WHERE oid = \$1", ["16"])
 data = columntable(result)
 
+# the same but asynchronously
+async_result = async_execute(conn, "SELECT typname FROM pg_type WHERE oid = \$1", ["16"])
+# do other things
+result = fetch(async_result)
+data = columntable(result)
+
 close(conn)
 ```
 

--- a/docs/src/pages/api.md
+++ b/docs/src/pages/api.md
@@ -54,6 +54,14 @@ LibPQ.CopyIn
 execute(::LibPQ.Connection, ::LibPQ.CopyIn)
 ```
 
+### Asynchronous
+
+```@docs
+async_execute
+LibPQ.AsyncResult
+cancel
+```
+
 ## Internals
 
 ### Connections

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -1,15 +1,17 @@
 module LibPQ
 
-export status, reset!, execute, prepare,
+export status, reset!, execute, prepare, async_execute, cancel,
     num_columns, num_rows, num_params, num_affected_rows
 
 
+using Base: Semaphore, acquire, release
 using Base.Iterators: zip, product
 using Base.Threads
 
 using Dates
 using DocStringExtensions
 using Decimals
+using FileWatching
 using Tables
 using IterTools: imap
 using LayerDicts
@@ -81,5 +83,7 @@ include("statements.jl")
 include("parsing.jl")
 include("copy.jl")
 include("tables.jl")
+
+include("asyncresults.jl")
 
 end

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -165,6 +165,9 @@ Calling `fetch` on the `AsyncResult` will return a [`Result`](@ref).
 All keyword arguments are the same as [`execute`](@ref) and are passed to the created
 `Result`.
 
+Only one `AsyncResult` can be active on a [`Connection`](@ref) at once.
+If multiple `AsyncResult`s use the same `Connection`, they will execute serially.
+
 `async_execute` does not yet support [`Statement`](@ref)s.
 
 `async_execute` optionally takes a `parameters` vector which passes query parameters as

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -204,7 +204,7 @@ function async_execute(
 end
 
 function _async_execute(
-    submission_fn::Base.Callable, jl_conn::Connection; throw_error::Bool=true, kwargs...
+    submission_fn::Function, jl_conn::Connection; throw_error::Bool=true, kwargs...
 )
     async_result = AsyncResult(jl_conn; kwargs...)
 

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -144,8 +144,6 @@ iserror(async_result::AsyncResult) = Base.istaskfailed(async_result.result_task)
 Base.isready(async_result::AsyncResult) = istaskdone(async_result.result_task)
 Base.wait(async_result::AsyncResult) = wait(async_result.result_task)
 Base.fetch(async_result::AsyncResult) = fetch(async_result.result_task)
-trywait(async_result::AsyncResult) = (try wait(async_result) catch end; nothing)
-trywait(::Nothing) = nothing
 Base.close(async_result::AsyncResult) = cancel(async_result)
 
 """

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -3,28 +3,24 @@ mutable struct AsyncResult
     "The LibPQ.jl Connection used for the query"
     jl_conn::Connection
 
-    "Whether this AsyncResult has locked the Connection"
-    conn_locked::Atomic{Bool}
-
     "Keyword arguments to pass to Result on creation"
     result_kwargs::Ref
+
+    "Whether or not the query should be cancelled, if running"
+    should_cancel::Bool
 
     "Task which errors or returns a LibPQ.jl Result which is created once available"
     result_task::Task
 
-    function AsyncResult(jl_conn::Connection, conn_locked::Atomic{Bool}, result_kwargs::Ref)
-        async_result = new(jl_conn, conn_locked, result_kwargs)
+    function AsyncResult(jl_conn::Connection, result_kwargs::Ref)
+        async_result = new(jl_conn, result_kwargs, false)
         jl_conn.async_result = async_result
         return async_result
     end
 end
 
-function AsyncResult(jl_conn::Connection, conn_locked::Atomic{Bool}; kwargs...)
-    return AsyncResult(jl_conn, conn_locked, Ref(kwargs))
-end
-
 function AsyncResult(jl_conn::Connection; kwargs...)
-    return AsyncResult(jl_conn, Atomic{Bool}(true); kwargs...)
+    return AsyncResult(jl_conn, Ref(kwargs))
 end
 
 function Base.show(io::IO, async_result::AsyncResult)
@@ -41,39 +37,9 @@ function Base.show(io::IO, async_result::AsyncResult)
 end
 
 """
-    _ensure_unlocked(async_result::AsyncResult) -> Bool
+    handle_result(async_result::AsyncResult; throw_error=true) -> Result
 
-If this [`AsyncResult`](@ref) had locked its [`Connection`](@ref), unlock it.
-
-Return whether the connection had been locked by this `AsyncResult`.
-"""
-function _ensure_unlocked(async_result::AsyncResult)
-    was_locked = atomic_xchg!(async_result.conn_locked, false)
-    if was_locked
-        async_result.jl_conn.async_result = nothing
-        unlock(async_result.jl_conn)
-    end
-    return was_locked
-end
-
-function handle_result(async_result::AsyncResult, success::Bool; throw_error=true)
-    log_function = throw_error ? error : warn
-
-    if success
-        async_result.result_task = consume(async_result; throw_error=throw_error)
-    else
-        msg = error_message(async_result.jl_conn)
-        _ensure_unlocked(async_result)
-        log_function(LOGGER, msg)
-    end
-
-    return async_result
-end
-
-"""
-    consume(async_result::AsyncResult; throw_error=true) -> Task
-
-Run a task which executes the query in `async_result` and waits for results.
+Executes the query in `async_result` and waits for results.
 
 This implements the loop described in the PostgreSQL documentation for
 [Asynchronous Command Processing](https://www.postgresql.org/docs/10/libpq-async.html).
@@ -82,92 +48,95 @@ The `throw_error` option only determines whether to throw errors when handling t
 [`Result`](@ref)s; the `Task` may error for other reasons related to processing the
 asynchronous loop.
 
-The result returned from the `Task` will be the [`Result`](@ref) of the last query run (the
-only query if using parameters).
-Any errors produced by the queries will be thrown together in a `CompositeException` by
-`@sync`.
+The result returned will be the [`Result`](@ref) of the last query run (the only query if
+using parameters).
+Any errors produced by the queries will be thrown together in a `CompositeException`.
 """
-function consume(async_result::AsyncResult; throw_error=true)
-    if !islocked(async_result.jl_conn) || !async_result.conn_locked[]
-        error("The AsyncResult must lock the Connection before calling `consume`")
-    end
-
-    async_task = @async begin
+function handle_result(async_result::AsyncResult; throw_error=true)
+    errors = []
+    result = nothing
+    for result_ptr in _consume(async_result.jl_conn)
         try
-            debug(LOGGER, "getting the socket fd")
-            pqfd = socket(async_result.jl_conn)
-            try
-                debug(LOGGER, "making an FDWatcher")
-                watcher = FDWatcher(pqfd, true, false)  # readable, not writeable
-                try
-                    last_result = @sync begin
-                        result = nothing
-                        debug(LOGGER, "beginning the waiting loop")
-                        while true
-                            debug(LOGGER, "waiting on the fd")
-                            wait(watcher)
-                            debug(LOGGER, "consuming input")
-                            success = libpq_c.PQconsumeInput(async_result.jl_conn.conn) == 1
-                            !success && error(error_message(async_result.jl_conn))
-                            debug(LOGGER, "checking isbusy")
-                            while libpq_c.PQisBusy(async_result.jl_conn.conn) == 0
-                                debug(LOGGER, "getting a result")
-                                result_ptr = libpq_c.PQgetResult(async_result.jl_conn.conn)
-                                result_ptr == C_NULL && @goto finished
-                                debug(LOGGER, "handling the non-null result")
-                                result = @async handle_result(Result(
-                                    result_ptr, async_result.jl_conn;
-                                    async_result.result_kwargs[]...
-                                ); throw_error=throw_error)
-                            end
-                        end
-                        @label finished
-                        debug(LOGGER, "finished the sync block")
-                        result
-                    end
-
-                    return fetch(last_result)
-                finally
-                    close(watcher)
-                end
-            finally
-                # I should maybe close pqfd here but I don't think that's possible since
-                # it's a file descriptor not a handle and it's not technically open
-            end
-        finally
-            # ensure the connection is unlocked
-            _ensure_unlocked(async_result)
-            debug(LOGGER, "finished the async block")
+            result = handle_result(
+                Result(
+                    result_ptr,
+                    async_result.jl_conn;
+                    async_result.result_kwargs[]...
+                );
+                throw_error=throw_error,
+            )
+        catch err
+            push!(errors, err)
         end
     end
 
-    return async_task
+    if throw_error && !isempty(errors)
+        throw(CompositeException(errors))
+    elseif result === nothing
+        error(LOGGER, "Async query did not return result")
+    else
+        return result
+    end
+end
+
+function _consume(jl_conn::Connection)
+    async_result = jl_conn.async_result
+    result_ptrs = Ptr{libpq_c.PGresult}[]
+    watcher = FDWatcher(socket(jl_conn), true, false)  # can wait for reads
+    try
+        while true
+            if async_result.should_cancel
+                debug(LOGGER, "Received cancel signal for connection $(jl_conn.conn)")
+                _cancel(jl_conn)
+            end
+            debug(LOGGER, "Waiting to read from connection $(jl_conn.conn)")
+            wait(watcher)
+            debug(LOGGER, "Consuming input from connection $(jl_conn.conn)")
+            success = libpq_c.PQconsumeInput(jl_conn.conn) == 1
+            !success && error(error_message(jl_conn))
+
+            while libpq_c.PQisBusy(jl_conn.conn) == 0
+                debug(LOGGER, "Checking the result from connection $(jl_conn.conn)")
+                result_ptr = libpq_c.PQgetResult(jl_conn.conn)
+                if result_ptr == C_NULL
+                    debug(LOGGER, "Finished reading from connection $(jl_conn.conn)")
+                    return result_ptrs
+                else
+                    result_num = length(result_ptrs) + 1
+                    debug(LOGGER,
+                        "Saving result $result_num from connection $(jl_conn.conn)"
+                    )
+                    push!(result_ptrs, result_ptr)
+                end
+            end
+        end
+    finally
+        close(watcher)
+    end
 end
 
 """
     cancel(async_result::AsyncResult)
 
-If this [`AsyncResult`](@ref) represents a currently-executing query, cancel it.
+If this [`AsyncResult`](@ref) represents a currently-executing query, attempt to cancel it.
 """
 function cancel(async_result::AsyncResult)
-    if !islocked(async_result.jl_conn) || !async_result.conn_locked[]
-        return
-    end
+    async_result.should_cancel = true
+    return
+end
 
-    cancel_ptr = libpq_c.PQgetCancel(async_result.jl_conn.conn)
+function _cancel(jl_conn::Connection)
+    cancel_ptr = libpq_c.PQgetCancel(jl_conn.conn)
     try
         # https://www.postgresql.org/docs/10/libpq-cancel.html#LIBPQ-PQCANCEL
         errbuf_size = 256
         errbuf = fill(0x0, errbuf_size)
         success = libpq_c.PQcancel(cancel_ptr, pointer(errbuf), errbuf_size) == 1
         if !success
-            error("Failed cancelling query: $(String(errbuf))")
+            warn(LOGGER, "Failed cancelling query: $(String(errbuf))")
+        else
+            debug(LOGGER, "Cancelled query for connection $(jl_conn.conn)")
         end
-
-        # in place of _ensure_unlocked, just wait for `consume` to call it
-        # this avoids "ERROR: connection pointer is NULL" which happens when conn unlocks
-        # itself
-        trywait(async_result)
     finally
         libpq_c.PQfreeCancel(cancel_ptr)
     end
@@ -210,41 +179,62 @@ As is normal for `Task`s, any exceptions will be thrown when calling `wait` or `
 """
 function async_execute end
 
-function async_execute(
-    jl_conn::Connection,
-    query::AbstractString;
-    throw_error::Bool=true,
-    kwargs...
-)
-    lock(jl_conn)
+function async_execute(jl_conn::Connection, query::AbstractString; kwargs...)
+    async_result = _async_execute(jl_conn; kwargs...) do jl_conn
+        _async_submit(jl_conn.conn, query)
+    end
 
-    success = _async_execute(jl_conn.conn, query)
-
-    return handle_result(AsyncResult(jl_conn; kwargs...), success; throw_error=throw_error)
+    return async_result
 end
 
 function async_execute(
     jl_conn::Connection,
     query::AbstractString,
     parameters::Union{AbstractVector, Tuple};
-    throw_error::Bool=true,
     kwargs...
 )
     string_params = string_parameters(parameters)
     pointer_params = parameter_pointers(string_params)
 
-    lock(jl_conn)
+    async_result = _async_execute(jl_conn; kwargs...) do jl_conn
+        _async_submit(jl_conn.conn, query, pointer_params)
+    end
 
-    success = _async_execute(jl_conn.conn, query, pointer_params)
-
-    return handle_result(AsyncResult(jl_conn; kwargs...), success; throw_error=throw_error)
-end
-
-function _async_execute(conn_ptr::Ptr{libpq_c.PGconn}, query::AbstractString)
-    return libpq_c.PQsendQuery(conn_ptr, query) == 1
+    return async_result
 end
 
 function _async_execute(
+    submission_fn::Base.Callable, jl_conn::Connection; throw_error::Bool=true, kwargs...
+)
+    async_result = AsyncResult(jl_conn; kwargs...)
+
+    async_result.result_task = @async lock(jl_conn) do
+        jl_conn.async_result = async_result
+
+        try
+            success = submission_fn(jl_conn)
+
+            if !success
+                # does not respect `throw_error` as there's no result to return on this error
+                error(LOGGER, error_message(async_result.jl_conn))
+            end
+
+            result = handle_result(async_result; throw_error=throw_error)
+
+            return result::Result
+        finally
+            jl_conn.async_result = nothing
+        end
+    end
+
+    return async_result
+end
+
+function _async_submit(conn_ptr::Ptr{libpq_c.PGconn}, query::AbstractString)
+    return libpq_c.PQsendQuery(conn_ptr, query) == 1
+end
+
+function _async_submit(
     conn_ptr::Ptr{libpq_c.PGconn},
     query::AbstractString,
     parameters::Vector{Ptr{UInt8}},

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -208,16 +208,11 @@ function _async_execute(
         jl_conn.async_result = async_result
 
         try
-            success = submission_fn(jl_conn)
+            # error if submission fails
+            # does not respect `throw_error` as there's no result to return on this error
+            submission_fn(jl_conn) || error(LOGGER, error_message(async_result.jl_conn))
 
-            if !success
-                # does not respect `throw_error` as there's no result to return on this error
-                error(LOGGER, error_message(async_result.jl_conn))
-            end
-
-            result = handle_result(async_result; throw_error=throw_error)
-
-            return result::Result
+            return handle_result(async_result; throw_error=throw_error)::Result
         finally
             jl_conn.async_result = nothing
         end

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -40,6 +40,13 @@ function Base.show(io::IO, async_result::AsyncResult)
     print(io, typeof(async_result), " (", status, ")")
 end
 
+"""
+    _ensure_unlocked(async_result::AsyncResult) -> Bool
+
+If this [`AsyncResult`](@ref) had locked its [`Connection`](@ref), unlock it.
+
+Return whether the connection had been locked by this `AsyncResult`.
+"""
 function _ensure_unlocked(async_result::AsyncResult)
     was_locked = atomic_xchg!(async_result.conn_locked, false)
     if was_locked
@@ -137,6 +144,11 @@ function consume(async_result::AsyncResult; throw_error=true)
     return async_task
 end
 
+"""
+    cancel(async_result::AsyncResult)
+
+If this [`AsyncResult`](@ref) represents a currently-executing query, cancel it.
+"""
 function cancel(async_result::AsyncResult)
     if !islocked(async_result.jl_conn) || !async_result.conn_locked[]
         return

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -13,9 +13,7 @@ mutable struct AsyncResult
     result_task::Task
 
     function AsyncResult(jl_conn::Connection, result_kwargs::Ref)
-        async_result = new(jl_conn, result_kwargs, false)
-        jl_conn.async_result = async_result
-        return async_result
+        return new(jl_conn, result_kwargs, false)
     end
 end
 

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -1,0 +1,242 @@
+"An asynchronous PostgreSQL query"
+mutable struct AsyncResult
+    "The LibPQ.jl Connection used for the query"
+    jl_conn::Connection
+
+    "Whether this AsyncResult has locked the Connection"
+    conn_locked::Atomic{Bool}
+
+    "Keyword arguments to pass to Result on creation"
+    result_kwargs::Ref
+
+    "Task which errors or returns a LibPQ.jl Result which is created once available"
+    result_task::Task
+
+    function AsyncResult(jl_conn::Connection, conn_locked::Atomic{Bool}, result_kwargs::Ref)
+        async_result = new(jl_conn, conn_locked, result_kwargs)
+        jl_conn.async_result = async_result
+        return async_result
+    end
+end
+
+function AsyncResult(jl_conn::Connection, conn_locked::Atomic{Bool}; kwargs...)
+    AsyncResult(jl_conn, conn_locked, Ref(kwargs))
+end
+
+function AsyncResult(jl_conn::Connection; kwargs...)
+    AsyncResult(jl_conn, Atomic{Bool}(true); kwargs...)
+end
+
+function Base.show(io::IO, async_result::AsyncResult)
+    status = if isready(async_result)
+        if iserror(async_result)
+            "errored"
+        else
+            "finished"
+        end
+    else
+        "in progress"
+    end
+    print(io, typeof(async_result), " (", status, ")")
+end
+
+function _ensure_unlocked(async_result::AsyncResult)
+    was_locked = atomic_xchg!(async_result.conn_locked, false)
+    if was_locked
+        async_result.jl_conn.async_result = nothing
+        unlock(async_result.jl_conn)
+    end
+    return was_locked
+end
+
+function handle_result(async_result::AsyncResult, success::Bool; throw_error=true)
+    log_function = throw_error ? error : warn
+
+    if success
+        async_result.result_task = consume(async_result; throw_error=throw_error)
+    else
+        msg = error_message(async_result.jl_conn)
+        _ensure_unlocked(async_result)
+        log_function(LOGGER, msg)
+    end
+
+    return async_result
+end
+
+"""
+    consume(async_result::AsyncResult; throw_error=true) -> Task
+
+Run a task which executes the query in `async_result` and waits for results.
+
+This implements the loop described in the PostgreSQL documentation for
+[Asynchronous Command Processing](https://www.postgresql.org/docs/10/libpq-async.html).
+
+The `throw_error` option only determines whether to throw errors when handling the new
+[`Result`](@ref)s; the `Task` may error for other reasons related to processing the
+asynchronous loop.
+
+The result returned from the `Task` will be the [`Result`](@ref) of the last query run (the
+only query if using parameters).
+Any errors produced by the queries will be thrown together in a `CompositeException` by
+`@sync`.
+"""
+function consume(async_result::AsyncResult; throw_error=true)
+    @async begin
+        try
+            debug(LOGGER, "getting our very own socket fd")
+            dup_fd = Libc.dup(socket(async_result.jl_conn))
+            try
+                debug(LOGGER, "making an FDWatcher")
+                watcher = FDWatcher(dup_fd, true, false)  # readable, not writeable
+                try
+                    last_result = @sync begin
+                        result = nothing
+                        debug(LOGGER, "beginning the waiting loop")
+                        while true
+                            debug(LOGGER, "waiting on the fd")
+                            wait(watcher)
+                            debug(LOGGER, "consuming input")
+                            success = libpq_c.PQconsumeInput(async_result.jl_conn.conn) == 1
+                            !success && error(error_message(async_result.jl_conn))
+                            debug(LOGGER, "checking isbusy")
+                            while libpq_c.PQisBusy(async_result.jl_conn.conn) == 0
+                                debug(LOGGER, "getting a result")
+                                result_ptr = libpq_c.PQgetResult(async_result.jl_conn.conn)
+                                result_ptr == C_NULL && @goto finished
+                                debug(LOGGER, "handling the non-null result")
+                                result = @async handle_result(Result(
+                                    result_ptr, async_result.jl_conn;
+                                    async_result.result_kwargs[]...
+                                ); throw_error=throw_error)
+                            end
+                        end
+                        @label finished
+                        debug(LOGGER, "finished the sync block")
+                        result
+                    end
+
+                    return fetch(last_result)
+                finally
+                    close(watcher)
+                end
+            finally
+                # I should maybe close dup_fd here but I don't think that's possible since
+                # it's a file descriptor not a handle and it's not technically open
+            end
+        finally
+            # ensure the connection is unlocked
+            _ensure_unlocked(async_result)
+            debug(LOGGER, "finished the async block")
+        end
+    end
+end
+
+function cancel(async_result::AsyncResult)
+    cancel_ptr = libpq_c.PQgetCancel(async_result.jl_conn.conn)
+    try
+        # https://www.postgresql.org/docs/10/libpq-cancel.html#LIBPQ-PQCANCEL
+        errbuf_size = 256
+        errbuf = fill(0x0, errbuf_size)
+        success = libpq_c.PQcancel(cancel_ptr, pointer(errbuf), errbuf_size) == 1
+        if !success
+            error("Failed cancelling query: $(String(errbuf))")
+        end
+
+        # in place of _ensure_unlocked, just wait for `consume` to call it
+        # this avoids "ERROR: connection pointer is NULL" which happens when conn unlocks
+        # itself
+        trywait(async_result)
+    finally
+        libpq_c.PQfreeCancel(cancel_ptr)
+    end
+end
+
+iserror(async_result::AsyncResult) = Base.istaskfailed(async_result.result_task)
+Base.isready(async_result::AsyncResult) = istaskdone(async_result.result_task)
+Base.wait(async_result::AsyncResult) = wait(async_result.result_task)
+Base.fetch(async_result::AsyncResult) = fetch(async_result.result_task)
+trywait(async_result::AsyncResult) = (try wait(async_result) catch end; nothing)
+trywait(::Nothing) = nothing
+Base.close(async_result::AsyncResult) = cancel(async_result)
+
+"""
+    async_execute(
+        jl_conn::Connection,
+        query::AbstractString,
+        [parameters::Union{AbstractVector, Tuple},]
+        kwargs...
+    ) -> AsyncResult
+
+Run a query on the PostgreSQL database and return an [`AsyncResult`](@ref).
+
+The `AsyncResult` contains a `Task` which processes a query asynchronously.
+Calling `fetch` on the `AsyncResult` will return a [`Result`](@ref).
+
+All keyword arguments are the same as [`execute`](@ref) and are passed to the created
+`Result`.
+
+`async_execute` does not yet support [`Statement`](@ref)s.
+
+`async_execute` optionally takes a `parameters` vector which passes query parameters as
+strings to PostgreSQL.
+Queries without parameters can contain multiple SQL statements, and the result of the final
+statement is returned.
+Any errors which occur during executed statements will be bundled together in a
+`CompositeException` and thrown.
+
+As is normal for `Task`s, any exceptions will be thrown when calling `wait` or `fetch`.
+"""
+function async_execute end
+
+function async_execute(
+    jl_conn::Connection,
+    query::AbstractString;
+    throw_error::Bool=true,
+    kwargs...
+)
+    lock(jl_conn)
+
+    success = _async_execute(jl_conn.conn, query)
+
+    return handle_result(AsyncResult(jl_conn; kwargs...), success; throw_error=throw_error)
+end
+
+function async_execute(
+    jl_conn::Connection,
+    query::AbstractString,
+    parameters::Union{AbstractVector, Tuple};
+    throw_error::Bool=true,
+    kwargs...
+)
+    string_params = string_parameters(parameters)
+    pointer_params = parameter_pointers(string_params)
+
+    lock(jl_conn)
+
+    success = _async_execute(jl_conn.conn, query, pointer_params)
+
+    return handle_result(AsyncResult(jl_conn; kwargs...), success; throw_error=throw_error)
+end
+
+function _async_execute(conn_ptr::Ptr{libpq_c.PGconn}, query::AbstractString)
+    libpq_c.PQsendQuery(conn_ptr, query) == 1
+end
+
+function _async_execute(
+    conn_ptr::Ptr{libpq_c.PGconn},
+    query::AbstractString,
+    parameters::Vector{Ptr{UInt8}},
+)
+    num_params = length(parameters)
+
+    libpq_c.PQsendQueryParams(
+        conn_ptr,
+        query,
+        num_params,
+        C_NULL,  # set paramTypes to C_NULL to have the server infer a type
+        parameters,
+        C_NULL,  # paramLengths is ignored for text format parameters
+        zeros(Cint, num_params),  # all parameters in text format
+        zero(Cint),  # return result in text format
+    ) == 1
+end

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -93,7 +93,7 @@ function _consume(jl_conn::Connection)
             wait(watcher)
             debug(LOGGER, "Consuming input from connection $(jl_conn.conn)")
             success = libpq_c.PQconsumeInput(jl_conn.conn) == 1
-            !success && error(error_message(jl_conn))
+            !success && error(LOGGER, error_message(jl_conn))
 
             while libpq_c.PQisBusy(jl_conn.conn) == 0
                 debug(LOGGER, "Checking the result from connection $(jl_conn.conn)")

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -119,6 +119,9 @@ end
 If this [`AsyncResult`](@ref) represents a currently-executing query, attempt to cancel it.
 """
 function cancel(async_result::AsyncResult)
+    # just sets the `should_cancel` flag
+    # the actual cancellation will be triggered in the main loop of _consume
+    # which will call `_cancel` on the `Connection`
     async_result.should_cancel = true
     return
 end

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -83,11 +83,11 @@ Any errors produced by the queries will be thrown together in a `CompositeExcept
 function consume(async_result::AsyncResult; throw_error=true)
     @async begin
         try
-            debug(LOGGER, "getting our very own socket fd")
-            dup_fd = Libc.dup(socket(async_result.jl_conn))
+            debug(LOGGER, "getting the socket fd")
+            pqfd = socket(async_result.jl_conn)
             try
                 debug(LOGGER, "making an FDWatcher")
-                watcher = FDWatcher(dup_fd, true, false)  # readable, not writeable
+                watcher = FDWatcher(pqfd, true, false)  # readable, not writeable
                 try
                     last_result = @sync begin
                         result = nothing
@@ -120,7 +120,7 @@ function consume(async_result::AsyncResult; throw_error=true)
                     close(watcher)
                 end
             finally
-                # I should maybe close dup_fd here but I don't think that's possible since
+                # I should maybe close pqfd here but I don't think that's possible since
                 # it's a file descriptor not a handle and it's not technically open
             end
         finally

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -130,7 +130,7 @@ function _cancel(jl_conn::Connection)
     try
         # https://www.postgresql.org/docs/10/libpq-cancel.html#LIBPQ-PQCANCEL
         errbuf_size = 256
-        errbuf = fill(0x0, errbuf_size)
+        errbuf = zeros(UInt8, errbuf_size)
         success = libpq_c.PQcancel(cancel_ptr, pointer(errbuf), errbuf_size) == 1
         if !success
             warn(LOGGER, "Failed cancelling query: $(String(errbuf))")

--- a/src/connections.jl
+++ b/src/connections.jl
@@ -630,4 +630,11 @@ function Base.show(io::IO, jl_conn::Connection)
     end
 end
 
-socket(jl_conn::Connection) = RawFD(libpq_c.PQsocket(jl_conn.conn))
+function socket(jl_conn::Connection)
+    socket_int = libpq_c.PQsocket(jl_conn.conn)
+    @static if Sys.iswindows()
+        Base.WindowsRawSocket(Ptr{Cvoid}(UInt64(socket_int)))
+    else
+        RawFD(socket_int)
+    end
+end

--- a/src/connections.jl
+++ b/src/connections.jl
@@ -532,7 +532,7 @@ end
 Construct a `ConnectionOption` from a `libpg_c.PQconninfoOption`.
 """
 function ConnectionOption(pq_opt::libpq_c.PQconninfoOption)
-    ConnectionOption(
+    return ConnectionOption(
         unsafe_string(pq_opt.keyword),
         unsafe_string_or_null(pq_opt.envvar),
         unsafe_string_or_null(pq_opt.compiled),
@@ -633,8 +633,8 @@ end
 function socket(jl_conn::Connection)
     socket_int = libpq_c.PQsocket(jl_conn.conn)
     @static if Sys.iswindows()
-        Base.WindowsRawSocket(Ptr{Cvoid}(UInt64(socket_int)))
+        return Base.WindowsRawSocket(Ptr{Cvoid}(UInt64(socket_int)))
     else
-        RawFD(socket_int)
+        return RawFD(socket_int)
     end
 end

--- a/src/connections.jl
+++ b/src/connections.jl
@@ -633,7 +633,7 @@ end
 function socket(jl_conn::Connection)
     socket_int = libpq_c.PQsocket(jl_conn.conn)
     @static if Sys.iswindows()
-        return Base.WindowsRawSocket(Ptr{Cvoid}(UInt64(socket_int)))
+        return Base.WindowsRawSocket(Ptr{Cvoid}(Int(socket_int)))
     else
         return RawFD(socket_int)
     end

--- a/src/headers/libpq-fe.jl
+++ b/src/headers/libpq-fe.jl
@@ -342,7 +342,7 @@ function PQfreeCancel(cancel)
     ccall((:PQfreeCancel, LIBPQ_HANDLE), Cvoid, (Ptr{PGcancel},), cancel)
 end
 
-function PQcancel(cancel, errbuf, errbufsize::Cint)
+function PQcancel(cancel, errbuf, errbufsize)
     ccall((:PQcancel, LIBPQ_HANDLE), Cint, (Ptr{PGcancel}, Cstring, Cint), cancel, errbuf, errbufsize)
 end
 

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -152,7 +152,8 @@ function load!(table::T, connection::Connection, query::AbstractString) where {T
     names = propertynames(row)
     sch = Tables.Schema(names, nothing)
     parameters = Vector{Parameter}(undef, length(names))
-    while true
+    while state !== nothing
+        row, st = state
         Tables.eachcolumn(sch, row) do val, col, nm
             parameters[col] = if ismissing(val)
                 missing
@@ -164,8 +165,6 @@ function load!(table::T, connection::Connection, query::AbstractString) where {T
         end
         close(execute(stmt, parameters; throw_error=true))
         state = iterate(rows, st)
-        state === nothing && break
-        row, st = state
     end
     return stmt
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1139,6 +1139,7 @@ end
             conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
 
             ar = async_execute(conn, "SELECT pg_sleep(2);"; throw_error=false)
+            yield()
             @test !isready(ar)
             @test !LibPQ.iserror(ar)
             @test conn.async_result === ar

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1220,8 +1220,12 @@ end
         @testset "Cancel" begin
             conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
 
-            # second query needs to be one that actually does something
-            ar = async_execute(conn, "SELECT pg_sleep(3); SELECT * FROM pg_type;")
+            # final query needs to be one that actually does something
+            # on Windows, first query also needs to do something
+            ar = async_execute(
+                conn,
+                "SELECT * FROM pg_opclass; SELECT pg_sleep(3); SELECT * FROM pg_type;",
+            )
             yield()
             @test !isready(ar)
             @test !LibPQ.iserror(ar)
@@ -1248,8 +1252,12 @@ end
         @testset "Canceled by closing connection" begin
             conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
 
-            # second query needs to be one that actually does something
-            ar = async_execute(conn, "SELECT pg_sleep(3); SELECT * FROM pg_type;")
+            # final query needs to be one that actually does something
+            # on Windows, first query also needs to do something
+            ar = async_execute(
+                conn,
+                "SELECT * FROM pg_opclass; SELECT pg_sleep(3); SELECT * FROM pg_type;",
+            )
             yield()
             @test !isready(ar)
             @test !LibPQ.iserror(ar)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -341,8 +341,15 @@ end
             result = execute(conn, copyin; throw_error=false)
             @test isopen(result)
             @test status(result) == LibPQ.libpq_c.PGRES_FATAL_ERROR
-            @test occursin("ERROR", LibPQ.error_message(result))
-            @test occursin("invalid input syntax for integer", LibPQ.error_message(result))
+
+            err_msg = LibPQ.error_message(result)
+            @test occursin("ERROR", err_msg)
+            if LibPQ.server_version(conn) >= v"12"
+                @test occursin("invalid input syntax for type bigint", err_msg)
+            else
+                @test occursin("invalid input syntax for integer", err_msg)
+            end
+
             close(result)
 
             result = execute(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -377,7 +377,7 @@ end
             @test was_open
             @test !isopen(saved_conn)
 
-            @test_throws ErrorException LibPQ.Connection("dbname=123fake"; throw_error=true) do jl_conn
+            @test_throws ErrorException LibPQ.Connection("dbname=123fake user=$DATABASE_USER"; throw_error=true) do jl_conn
                 @test false
             end
         end
@@ -536,7 +536,7 @@ end
 
         @testset "Bad Connection" begin
             @testset "throw_error=false" begin
-                conn = LibPQ.Connection("dbname=123fake"; throw_error=false)
+                conn = LibPQ.Connection("dbname=123fake user=$DATABASE_USER"; throw_error=false)
                 @test conn isa LibPQ.Connection
                 @test status(conn) == LibPQ.libpq_c.CONNECTION_BAD
                 @test isopen(conn)
@@ -552,9 +552,9 @@ end
             end
 
             @testset "throw_error=true" begin
-                @test_throws ErrorException LibPQ.Connection("dbname=123fake"; throw_error=true)
+                @test_throws ErrorException LibPQ.Connection("dbname=123fake user=$DATABASE_USER"; throw_error=true)
 
-                conn = LibPQ.Connection("dbname=123fake"; throw_error=false)
+                conn = LibPQ.Connection("dbname=123fake user=$DATABASE_USER"; throw_error=false)
                 @test conn isa LibPQ.Connection
                 @test status(conn) == LibPQ.libpq_c.CONNECTION_BAD
                 @test isopen(conn)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1135,6 +1135,8 @@ end
     end
 
     @testset "AsyncResults" begin
+        trywait(ar::LibPQ.AsyncResult) = (try wait(ar) catch end; nothing)
+
         @testset "Basic" begin
             conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
 
@@ -1233,7 +1235,7 @@ end
             @test conn.async_result === ar
 
             cancel(ar)
-            LibPQ.trywait(ar)
+            trywait(ar)
             @test isready(ar)
             @test LibPQ.iserror(ar)
             @test conn.async_result === nothing
@@ -1265,7 +1267,7 @@ end
             @test conn.async_result === ar
 
             close(conn)
-            LibPQ.trywait(ar)
+            trywait(ar)
             @test isready(ar)
             @test LibPQ.iserror(ar)
             @test conn.async_result === nothing


### PR DESCRIPTION
Adds support for asynchronous execution using https://www.postgresql.org/docs/10/libpq-async.html

TODO:
- [x] A few more docstrings
- [x] General docs
- [x] More tests for atypical behaviour (e.g., closing a connection before a query finishes)
- [x] Test with `task.sticky = false`
  - Currently deadlocks (I think during cancellation but I'm not sure) when using `@par`, will wait another release to be sure it's not a bad interaction with the uv event loop