### PR TITLE
Tweak readme given BinaryProvider build

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ LibPQ.jl is a Julia wrapper for the PostgreSQL `libpq` C library.
 ### Current
 
 * Build
-  * Installs `libpq` with Apt, Yum, or Homebrew
+  * Installs `libpq` via `BinaryProvider` for MacOS, GNU Linux, and Windows
 * Connections
   * Connect via DSN
   * Connect via PostgreSQL connection string


### PR DESCRIPTION
Very minor edit!
I just noticed what looked like an old `BinDeps` style build note in the readme, yet master has a `BinaryProvider`-based build.