### PR TITLE
Add finalizer to Connection (that doesn't task-switch)

### DIFF
--- a/src/connections.jl
+++ b/src/connections.jl
@@ -181,6 +181,8 @@ function Connection(
     if libpq_c.PQconnectionNeedsPassword(jl_conn.conn) == 1
         push!(keywords, "password")
         user = unsafe_string(libpq_c.PQuser(jl_conn.conn))
+        # close this connection; will open another one below with the user-provided password
+        close(jl_conn)
         prompt = "Enter password for PostgreSQL user $user:"
         pass = Base.getpass(prompt)
         push!(values, read(pass, String))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -385,8 +385,11 @@ end
             @test !isopen(saved_conn)
 
             @test_throws ErrorException LibPQ.Connection("dbname=123fake user=$DATABASE_USER"; throw_error=true) do jl_conn
+                saved_conn = jl_conn
                 @test false
             end
+
+            @test !isopen(saved_conn)
         end
 
         @testset "Version Numbers" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -541,6 +541,19 @@ end
             end
         end
 
+        @testset "Finalizer" begin
+            closed_flags = map(1:50) do _
+                conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER")
+                closed = conn.closed
+                finalize(conn)
+                return closed
+            end
+
+            sleep(1)
+
+            @test all(closed -> closed[], closed_flags)
+        end
+
         @testset "Bad Connection" begin
             @testset "throw_error=false" begin
                 conn = LibPQ.Connection("dbname=123fake user=$DATABASE_USER"; throw_error=false)


### PR DESCRIPTION
Closes #111 

This adds a finalizer that just creates a task which closes the connection in the simplest way possible.

I also added a missing `close` that only applies when the user is interactively entering a password.