### PR TITLE
Catch EBADF from FDWatcher and replace with JLConnectionError

### DIFF
--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -108,6 +108,15 @@ function _consume(jl_conn::Connection)
                 end
             end
         end
+    catch err
+        if err isa Base.IOError && err.code == -9  # EBADF
+            debug(() -> sprint(showerror, err), LOGGER)
+            error(LOGGER, Errors.JLConnectionError(
+                "PostgreSQL connection socket was unexpectedly closed"
+            ))
+        else
+            rethrow(err)
+        end
     finally
         close(watcher)
     end


### PR DESCRIPTION
A few people have seen this come up when running queries against Amazon Aurora. My theory is the socket is being closed (by the server) before `wait(watcher)` is called. Throwing a better error allows the caller to identify the error as coming from the LibPQ Connection.