### PR TITLE
Cache columns to avoid escaping

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -88,7 +88,7 @@ end
 
 function Column(jl_result::Result, col::Integer, name=Symbol(column_name(jl_result, col)))
     @boundscheck if !checkindex(Bool, Base.OneTo(num_columns(jl_result)), col)
-        throw(BoundsError(Columns(jl_result)), col)
+        throw(BoundsError(Columns(jl_result), col))
     end
 
     oid = column_oids(jl_result)[col]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -852,10 +852,10 @@ end
             @test LibPQ.column_number(result, :Column) == 1
 
             table = Tables.columntable(result)
-            @test hasproperty(table, :Column)
+            @test :Column in propertynames(table)
 
             table = Tables.rowtable(result)
-            @test hasproperty(table[1], :Column)
+            @test :Column in propertynames(table[1])
 
             close(result)
             close(conn)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -843,6 +843,24 @@ end
             close(conn)
         end
 
+        @testset "Uppercase Columns" begin
+            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+
+            result = execute(conn, "SELECT 1 AS \"Column\";")
+            @test num_columns(result) == 1
+            @test LibPQ.column_name(result, 1) == "Column"
+            @test LibPQ.column_number(result, :Column) == 1
+
+            table = Tables.columntable(result)
+            @test hasproperty(table, :Column)
+
+            table = Tables.rowtable(result)
+            @test hasproperty(table[1], :Column)
+
+            close(result)
+            close(conn)
+        end
+
         @testset "PQResultError" begin
             conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
 


### PR DESCRIPTION
It turns out that when PostgreSQL returns capitalized columns (or other special column names), they need to be escaped with `""` before they are passed back into other `libpq` functions. Escaping requires the connection, but we've discarded that. So here we just store the column names ourselves and do the lookup ourselves.