### PR TITLE
Add connection timeout

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -590,6 +590,18 @@ end
         end
 
         @testset "Bad Connection" begin
+            @testset "timeout" begin
+                try
+                    # could be any SSL connection, just need to get through one stage of
+                    # processing successfully so it has an opportunity to time out
+                    LibPQ.Connection("host=enterprisedb.com port=443"; connect_timeout=0.01)
+                    @test false
+                catch err
+                    @test err isa LibPQ.Errors.JLConnectionError
+                    @test occursin("timed out", sprint(showerror, err))
+                end
+            end
+
             @testset "throw_error=false" begin
                 conn = LibPQ.Connection("dbname=123fake user=$DATABASE_USER"; throw_error=false)
                 @test conn isa LibPQ.Connection


### PR DESCRIPTION
This will not timeout early in cases like this:
```
ERROR: could not connect to server: Operation timed out
    Is the server running on host "example.com" (93.184.216.34) and accepting
    TCP/IP connections on port 22?
```
This will only timeout if the connection process is sending/receiving data to/from the server, thus yielding and letting us check the timer. ~If Julia had a `select` we could use it here, but it does not.~

~`timedwait` could be used here instead of `wait`, but it's difficult to guess an appropriate polling interval, and apparently it's buggy and inconsistent.~

~Next version will have the loop in a task and a sleeper task that both notify the same condition, like how [`poll_fd`](https://github.com/JuliaLang/julia/blob/872d8ea0358f7431ace85498a1761253773068dc/stdlib/FileWatching/src/FileWatching.jl#L649) works.~

It turns out you _must_ call `PQconnectPoll` after waiting on the socket, or later connections that reuse the socket (which `libpq` is free to create) will hang indefinitely. So this is the best we can do.