### PR TITLE
Reduce query frequency of consume

### DIFF
--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -83,6 +83,8 @@ function _consume(jl_conn::Connection)
     watcher = FDWatcher(socket(jl_conn), true, false)  # can wait for reads
     try
         while true
+            start = time()
+
             if async_result.should_cancel
                 debug(LOGGER, "Received cancel signal for connection $(jl_conn.conn)")
                 _cancel(jl_conn)
@@ -107,6 +109,10 @@ function _consume(jl_conn::Connection)
                     push!(result_ptrs, result_ptr)
                 end
             end
+
+            # Wait at least a second between polling
+            duration = time() - start
+            sleep(max(1 - duration, 0))
         end
     catch err
         if err isa Base.IOError && err.code == -9  # EBADF

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -112,7 +112,7 @@ function _consume(jl_conn::Connection)
 
             # Wait at least a second between polling
             duration = time() - start
-            sleep(max(1 - duration, 0))
+            sleep(max(0.5 - duration, 0.0))
         end
     catch err
         if err isa Base.IOError && err.code == -9  # EBADF

--- a/src/asyncresults.jl
+++ b/src/asyncresults.jl
@@ -110,7 +110,7 @@ function _consume(jl_conn::Connection)
                 end
             end
 
-            # Wait at least a second between polling
+            # Wait at least a half-second between polling
             duration = time() - start
             sleep(max(0.5 - duration, 0.0))
         end


### PR DESCRIPTION
It appears that there is lots of activity on the connection which ends up making debug logs very spammy and probably ends up using up system resources unnecessarily.
```
[2019-11-14 19:20:28 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:28 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:28 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:28 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:28 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
... (904 more lines)
[2019-11-14 19:20:28 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:28 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:29 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:29 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:29 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:29 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
... (1741 more lines)
[2019-11-14 19:20:29 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:29 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:36 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:36 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:36 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:36 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
... (428 more lines)
[2019-11-14 19:20:36 debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:36 debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:37 debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:37 debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:37 debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:37 debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
... (5340 more lines)
[2019-11-14 19:20:37 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:37 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:38 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:38 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:38 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:38 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:38 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:38 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
... (1912 more lines)
[2019-11-14 19:20:38 | debug | LibPQ]: Waiting to read from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:38 | debug | LibPQ]: Consuming input from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:38 | debug | LibPQ]: Checking the result from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:38 | debug | LibPQ]: Saving result 1 from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:38 | debug | LibPQ]: Checking the result from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:38 | debug | LibPQ]: Finished reading from connection Ptr{Nothing} @0x000000000500a110
[2019-11-14 19:20:38 | debug | LibPQ]: SELECT 2566102
```
With the change I made we'll wait at minimum of one second between polling to read the connection.