### PR TITLE
Fix EBADF test to catch any of the possible messages

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -611,16 +611,12 @@ end
                     close(Base.Libc.FILE(LibPQ.socket(conn), "r"))  # close socket
                     LibPQ._connect_poll(conn, Timer(0), 0)
 
-                    errs = map(LibPQ.Errors.PQConnectionError, [
-                        "could not receive data from server: Bad file descriptor\n",
-                        "could not get socket error status: Bad file descriptor\n",
-                    ])
-
                     try
                         LibPQ.handle_new_connection(LibPQ.Connection(conn))
                         @test false
                     catch err
-                        @test err in errs
+                        @test err isa LibPQ.Errors.PQConnectionError
+                        @test occursin("Bad file descriptor", sprint(show, err))
                     end
                 end
             end


### PR DESCRIPTION
There are more possible messages than I thought, and you can get multiple messages at once, but they all contain "Bad file descriptor" so I'll just check for that text.