### PR TITLE
Fix and test CEnum printing behaviour

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 BinaryProvider = "0.5"
-CEnum = "0.1.1, 0.2"
+CEnum = "0.2"
 DataFrames = "0.14, 0.15, 0.16, 0.17, 0.18, 0.19"
 Decimals = "0.3.1, 0.4"
 DocStringExtensions = "0.8.0"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,5 +1,3 @@
-# This file is machine-generated - editing it directly is not advised
-
 [[ArnoldiMethod]]
 deps = ["DelimitedFiles", "LinearAlgebra", "Random", "SparseArrays", "StaticArrays", "Test"]
 git-tree-sha1 = "2b6845cea546604fb4dca4e31414a6a59d39ddcd"
@@ -10,38 +8,32 @@ version = "0.0.4"
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryProvider]]
-deps = ["Libdl", "Logging", "SHA"]
-git-tree-sha1 = "c7361ce8a2129f20b0e05a89f7070820cfed6648"
+deps = ["Libdl", "SHA"]
+git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.5.6"
+version = "0.5.8"
 
 [[CEnum]]
-git-tree-sha1 = "5a2679abe17f5e70d90753940dcb7f15e61369d4"
+git-tree-sha1 = "62847acab40e6855a9b5905ccb99c2b5cf6b3ebb"
 uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
-version = "0.1.2"
-
-[[CSTParser]]
-deps = ["Tokenize"]
-git-tree-sha1 = "c69698c3d4a7255bc1b4bc2afc09f59db910243b"
-uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "0.6.2"
+version = "0.2.0"
 
 [[CategoricalArrays]]
-deps = ["Compat", "DataAPI", "Future", "JSON", "Missings", "Printf", "Reexport"]
-git-tree-sha1 = "13240cfcc884837fc1aa89b60d500a652bcc3f10"
+deps = ["Compat", "DataAPI", "Future", "JSON", "Missings", "Printf", "Reexport", "Unicode"]
+git-tree-sha1 = "4d85a015093760ff23b20f3e25fa195b4cb76794"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.5.5"
+version = "0.7.3"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
+git-tree-sha1 = "ed2c4abadf84c53d9e58510b5fc48912c2336fbb"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "2.1.0"
+version = "2.2.0"
 
 [[DataAPI]]
-git-tree-sha1 = "8903f0219d3472543fc4b2f5ebaf675a07f817c0"
+git-tree-sha1 = "674b67f344687a88310213ddfa8a2b3c76cc4252"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.0.1"
+version = "1.1.0"
 
 [[DataFrames]]
 deps = ["CategoricalArrays", "Compat", "IteratorInterfaceExtensions", "Missings", "PooledArrays", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "StatsBase", "TableTraits", "Tables", "Unicode"]
@@ -51,9 +43,9 @@ version = "0.18.4"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "0809951a1774dc724da22d26e4289bbaab77809a"
+git-tree-sha1 = "a1b652fb77ae8ca7ea328fa7ba5aa151036e5c10"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.0"
+version = "0.17.6"
 
 [[DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -75,14 +67,14 @@ deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
 deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "0513f1a8991e9d83255e0140aace0d0fc4486600"
+git-tree-sha1 = "88bb0edb352b16608036faadcc071adda068582a"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.0"
+version = "0.8.1"
 
 [[Documenter]]
 deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Unicode"]
@@ -92,9 +84,9 @@ version = "0.22.6"
 
 [[EzXML]]
 deps = ["BinaryProvider", "Libdl", "Printf"]
-git-tree-sha1 = "724e13b7522563a18ae4a5cc4a9792ae3b0da3e6"
+git-tree-sha1 = "469de9cb996a9c03f31905619ff3c33e905711f3"
 uuid = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
-version = "0.9.3"
+version = "0.9.5"
 
 [[FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
@@ -110,13 +102,13 @@ uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
 version = "0.1.1"
 
 [[InteractiveUtils]]
-deps = ["Markdown"]
+deps = ["LinearAlgebra", "Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[IterTools]]
-git-tree-sha1 = "2ebe60d7343962966d1779a74a760f13217a6901"
+git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
 uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
-version = "1.2.0"
+version = "1.3.0"
 
 [[IteratorInterfaceExtensions]]
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
@@ -147,7 +139,7 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 deps = ["BinaryProvider", "CEnum", "Dates", "Decimals", "DocStringExtensions", "FileWatching", "IterTools", "LayerDicts", "Libdl", "Memento", "OffsetArrays", "Tables", "TimeZones"]
 path = ".."
 uuid = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
-version = "0.11.0"
+version = "1.0.5"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -166,10 +158,10 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[MacroTools]]
-deps = ["CSTParser", "Compat", "DataStructures", "Test", "Tokenize"]
-git-tree-sha1 = "d6e9dedb8c92c3465575442da456aec15a89ff76"
+deps = ["Compat", "DataStructures", "Test"]
+git-tree-sha1 = "82921f0e3bde6aebb8e524efc20f4042373c0c06"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.1"
+version = "0.5.2"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -182,24 +174,23 @@ uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 version = "0.12.1"
 
 [[Missings]]
-deps = ["SparseArrays", "Test"]
-git-tree-sha1 = "f0719736664b4358aa9ec173077d4285775f8007"
+deps = ["DataAPI"]
+git-tree-sha1 = "de0a5ce9e5289f27df672ffabef4d1e5861247d5"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.4.1"
+version = "0.4.3"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[Mocking]]
-deps = ["Compat", "Dates"]
-git-tree-sha1 = "4bf69aaf823b119b034e091e16b18311aa191663"
+git-tree-sha1 = "bd2623f8b728af988d2afec53d611acb621f3bc4"
 uuid = "78c3b35d-d492-501b-9361-3d52fe80e533"
-version = "0.5.7"
+version = "0.7.0"
 
 [[OffsetArrays]]
-git-tree-sha1 = "1af2f79c7eaac3e019a0de41ef63335ff26a0a57"
+git-tree-sha1 = "1ae707306f6e33dbb37d0742e08828562772b73f"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "0.11.1"
+version = "0.11.2"
 
 [[OrderedCollections]]
 deps = ["Random", "Serialization", "Test"]
@@ -246,9 +237,9 @@ uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
 [[SimpleTraits]]
 deps = ["InteractiveUtils", "MacroTools"]
-git-tree-sha1 = "05bbf4484b975782e5e54bb0750f21f7f2f66171"
+git-tree-sha1 = "2bdf3b6300a9d66fe29ee8bb51ba100c4df9ecbc"
 uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
-version = "0.9.0"
+version = "0.9.1"
 
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -265,9 +256,9 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "db23bbf50064c582b6f2b9b043c8e7e98ea8c0c6"
+git-tree-sha1 = "5a3bcb6233adabde68ebc97be66e95dcb787424c"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.11.0"
+version = "0.12.1"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -315,17 +306,12 @@ version = "3.0.5"
 
 [[TimeZones]]
 deps = ["Dates", "EzXML", "Mocking", "Printf", "Serialization", "Unicode"]
-git-tree-sha1 = "0271dc890dd1447da1568510937bd5b3a6b51b58"
+git-tree-sha1 = "29c7ae3f50f291358043e21db47b3e1a516df891"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "0.9.2"
-
-[[Tokenize]]
-git-tree-sha1 = "c8a8b00ae44a94950814ff77850470711a360225"
-uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.5"
+version = "0.10.3"
 
 [[UUIDs]]
-deps = ["Random", "SHA"]
+deps = ["Random"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -74,9 +74,13 @@ end
 
 include("error_codes.jl")
 
-# use enum_name to get "C42" rather than "C42(31)"
-Base.show(io::IO, class::Class) = print(io, CEnum.enum_name(class))
-Base.show(io::IO, code::ErrorCode) = print(io, CEnum.enum_name(code))
+# avoid exposing the meaningless integer value of the enum
+function Base.show(io::IO, ::MIME"text/plain", class::Class)
+    print(io, class, "::", typeof(class))
+end
+function Base.show(io::IO, ::MIME"text/plain", code::ErrorCode)
+    print(io, code, "::", typeof(code))
+end
 
 Base.parse(::Type{Class}, str::AbstractString) = getfield(Errors, Symbol("C", str))
 Base.parse(::Type{ErrorCode}, str::AbstractString) = getfield(Errors, Symbol("E", str))

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -57,7 +57,7 @@ julia> try execute(conn, "SELORCT NUUL;") catch err println(err) end
 LibPQ.Errors.SyntaxError("ERROR:  syntax error at or near \\"SELORCT\\"\\nLINE 1: SELORCT NUUL;\\n        ^\\n")
 
 julia> LibPQ.Errors.SyntaxError
-LibPQ.Errors.PQResultError{C42,E42601}
+LibPQ.Errors.PQResultError{LibPQ.Errors.C42,LibPQ.Errors.E42601}
 ```
 """
 struct PQResultError{Class, Code} <: PostgreSQLException

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -905,6 +905,18 @@ end
                 @test LibPQ.Errors.error_code(err) == LibPQ.Errors.E2201E
             end
 
+            @test sprint(show, LibPQ.Errors.C22) == "LibPQ.Errors.C22"
+            @test string(LibPQ.Errors.C22) == "C22"
+            @test sprint(LibPQ.Errors.C22) do io, class
+                show(io, MIME"text/plain"(), class)
+            end == "C22::LibPQ.Errors.Class"
+
+            @test sprint(show, LibPQ.Errors.E2201E) == "LibPQ.Errors.E2201E"
+            @test string(LibPQ.Errors.E2201E) == "E2201E"
+            @test sprint(LibPQ.Errors.E2201E) do io, code
+                show(io, MIME"text/plain"(), code)
+            end == "E2201E::LibPQ.Errors.ErrorCode"
+
             result = execute(conn, "SELECT log(-1);"; throw_error=false)
             err = LibPQ.Errors.PQResultError(result; verbose=false)
             verbose_err = LibPQ.Errors.PQResultError(result; verbose=true)


### PR DESCRIPTION
If `show(::IO, ::T)` is overloaded on a type parameter `T` you can get stuff like this:

```
caused by [exception 2]
UndefVarError: enum_name not defined
Stacktrace:
 [1] getproperty at ./Base.jl:13 [inlined]
 [2] show(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::LibPQ.Errors.Class) at /mnt/builds/as3upHg9/1/invenia/BidDatabase.jl.tmp/depot/packages/LibPQ/JZUG4/src/exceptions.jl:78
 [3] show_datatype(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::DataType) at ./show.jl:533
 [4] show(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Type) at ./show.jl:434
 [5] print(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Type) at ./strings/io.jl:35
 [6] print(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::String, ::Type) at ./strings/io.jl:46
 [7] show_tuple_as_call(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Symbol, ::Type) at ./show.jl:1526
 [8] show_spec_linfo(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Base.StackTraces.StackFrame) at ./stacktraces.jl:262
 [9] #show#9(::Bool, ::typeof(show), ::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Base.StackTraces.StackFrame) at ./stacktraces.jl:272
 [10] #show at ./none:0 [inlined]
 [11] #show_trace_entry#673(::String, ::typeof(Base.show_trace_entry), ::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Base.StackTraces.StackFrame, ::Int32) at ./errorshow.jl:483
 [12] (::Base.var"#kw##show_trace_entry")(::NamedTuple{(:prefix,),Tuple{String}}, ::typeof(Base.show_trace_entry), ::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Base.StackTraces.StackFrame, ::Int32) at ./none:0
 [13] show_backtrace(::Base.GenericIOBuffer{Array{UInt8,1}}, ::Array{Union{Ptr{Nothing}, Base.InterpreterIP},1}) at ./errorshow.jl:586
 [14] #showerror#656(::Bool, ::typeof(showerror), ::Base.GenericIOBuffer{Array{UInt8,1}}, ::LibPQ.Errors.PQResultError{fatal: error thrown and no exception handler available.
UndefVarError(var=:enum_name)
rec_backtrace at /buildworker/worker/package_linux32/build/src/stackwalk.c:94
record_backtrace at /buildworker/worker/package_linux32/build/src/task.c:224 [inlined]
jl_throw at /buildworker/worker/package_linux32/build/src/task.c:461
jl_undefined_var_error at /buildworker/worker/package_linux32/build/src/rtutils.c:130
jl_get_binding_or_error at /buildworker/worker/package_linux32/build/src/module.c:308
getproperty at ./Base.jl:13 [inlined]
show at /mnt/builds/as3upHg9/1/invenia/BidDatabase.jl.tmp/depot/packages/LibPQ/JZUG4/src/exceptions.jl:78
unknown function (ip: 0xa0563765)
_jl_invoke at /buildworker/worker/package_linux32/build/src/gf.c:2141 [inlined]
jl_apply_generic at /buildworker/worker/package_linux32/build/src/gf.c:2305
show_datatype at ./show.jl:533
show at ./show.jl:434
_jl_invoke at /buildworker/worker/package_linux32/build/src/gf.c:2135 [inlined]
jl_apply_generic at /buildworker/worker/package_linux32/build/src/gf.c:2305
print at ./strings/io.jl:35
_jl_invoke at /buildworker/worker/package_linux32/build/src/gf.c:2135 [inlined]
jl_apply_generic at /buildworker/worker/package_linux32/build/src/gf.c:2305
print at ./strings/io.jl:46
_jl_invoke at /buildworker/worker/package_linux32/build/src/gf.c:2135 [inlined]
jl_apply_generic at /buildworker/worker/package_linux32/build/src/gf.c:2305
show_tuple_as_call at ./show.jl:1526
_jl_invoke at /buildworker/worker/package_linux32/build/src/gf.c:2135 [inlined]
jl_apply_generic at /buildworker/worker/package_linux32/build/src/gf.c:2305
show_spec_linfo at ./stacktraces.jl:262
#show#9 at ./stacktraces.jl:272
#show at ./none:0 [inlined]
#show_trace_entry#673 at ./errorshow.jl:483
#show_trace_entry at ./none:0
unknown function (ip: 0xa055ce10)
_jl_invoke at /buildworker/worker/package_linux32/build/src/gf.c:2135 [inlined]
jl_apply_generic at /buildworker/worker/package_linux32/build/src/gf.c:2305
show_backtrace at ./errorshow.jl:586
#showerror#656 at ./errorshow.jl:79
#showerror at ./none:0
unknown function (ip: 0xa055ae2b)
_jl_invoke at /buildworker/worker/package_linux32/build/src/gf.c:2135 [inlined]
jl_apply_generic at /buildworker/worker/package_linux32/build/src/gf.c:2305
show_exception_stack at ./errorshow.jl:649
display_error at ./client.jl:102
_jl_invoke at /buildworker/worker/package_linux32/build/src/gf.c:2141 [inlined]
jl_apply_generic at /buildworker/worker/package_linux32/build/src/gf.c:2305
display_error at ./client.jl:104
_jl_invoke at /buildworker/worker/package_linux32/build/src/gf.c:2141 [inlined]
jl_apply_generic at /buildworker/worker/package_linux32/build/src/gf.c:2305
jl_apply at /buildworker/worker/package_linux32/build/src/julia.h:1631 [inlined]
jl_f__apply at /buildworker/worker/package_linux32/build/src/builtins.c:627
jl_f__apply_latest at /buildworker/worker/package_linux32/build/src/builtins.c:665
#invokelatest#1 at ./essentials.jl:709 [inlined]
invokelatest at ./essentials.jl:708 [inlined]
_start at ./client.jl:462
jfptr__start_2078 at /mnt/builds/as3upHg9/1/invenia/BidDatabase.jl.tmp/julia/lib/julia/sys.so (unknown line)
_jl_invoke at /buildworker/worker/package_linux32/build/src/gf.c:2135 [inlined]
jl_apply_generic at /buildworker/worker/package_linux32/build/src/gf.c:2305
jl_apply at /buildworker/worker/package_linux32/build/ui/../src/julia.h:1631 [inlined]
true_main at /buildworker/worker/package_linux32/build/ui/repl.c:96
main at /buildworker/worker/package_linux32/build/ui/repl.c:217
__libc_start_main at /lib/i386-linux-gnu/libc.so.6 (unknown line)
_start at /mnt/builds/as3upHg9/1/invenia/BidDatabase.jl.tmp/julia/bin/julia (unknown line)
```

CEnum 0.2 has nicer printing, so we can switch to just overriding `show(::IO, ::MIME"text/plain", ::Union{Class, ErrorCode})`

Fixes https://github.com/invenia/LibPQ.jl/issues/143