### PR TITLE
Support TimeZones 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,10 +26,10 @@ Decimals = "0.3.1, 0.4"
 DocStringExtensions = "0.8.0"
 IterTools = "1"
 LayerDicts = "1"
-Memento = "0.10, 0.11, 0.12"
+Memento = "0.10, 0.11, 0.12, 0.13, 1"
 OffsetArrays = "0.9.1, 0.10, 0.11"
 Tables = "0.2"
-TimeZones = "0.9.2, 0.10"
+TimeZones = "0.9.2, 0.10, 0.11, 1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
I tested locally which worked fine. Note that due to an issue with the package registry Memento.jl is forcing TimeZones to be bounded be `[0.9.2, 1)`. Once a new Memento release is made then version 1.0 of TimeZones can be used which is why I pre-emptively added 0.13 and 1 for Memento.