### PR TITLE
Fix brew service issue on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
       env:
         - PGPORT=5432 LIBPQJL_DATABASE_USER=travis
       before_install:
+        - brew update
         - brew services start postgresql
     - julia: 1.0
       os: linux


### PR DESCRIPTION
Possibly a temporary fix, as it seems that a newer version of brew fixes this issue, so it might be that the image that's used just needs to update its brew install

fixes #158 

This seems to fix the brew services issue, but now I'm not sure why postgres isn't starting on the linux machines.