### PR TITLE
Postgres password for unit tests

### DIFF
--- a/docs/src/pages/faq.md
+++ b/docs/src/pages/faq.md
@@ -21,7 +21,7 @@ To set the database user used to connect to the database, use the `LIBPQJL_DATAB
 A simple way to set up a server for testing is to use [Docker](https://hub.docker.com/search/?type=edition&offering=community):
 
 ```sh
-docker run --detach --name test-libpqjl -p 5432:5432 postgres
+docker run --detach --name test-libpqjl -p 5432:5432 -e POSTGRES_PASSWORD=Password12! postgres
 ```
 
 To set any other client options for connecting to the test database, use the [PostgreSQL environment variables](https://www.postgresql.org/docs/11/libpq-envars.html).


### PR DESCRIPTION
When I try to start the Postgres container for the unit tests using the command
`docker run --detach --name test-libpqjl -p 5432:5432 postgres`
Postgres gives the following error message
`Error: Database is uninitialized and superuser password is not specified.`
This PR adds the possibility to define a password for the unit test Postgres instance via environment variable, with a given default.