### PR TITLE
Update docs on docker image to use trust auth for testing

### DIFF
--- a/docs/src/pages/faq.md
+++ b/docs/src/pages/faq.md
@@ -21,7 +21,7 @@ To set the database user used to connect to the database, use the `LIBPQJL_DATAB
 A simple way to set up a server for testing is to use [Docker](https://hub.docker.com/search/?type=edition&offering=community):
 
 ```sh
-docker run --detach --name test-libpqjl -p 5432:5432 postgres
+docker run --detach --name test-libpqjl -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 postgres
 ```
 
-To set any other client options for connecting to the test database, use the [PostgreSQL environment variables](https://www.postgresql.org/docs/11/libpq-envars.html).
+To set any other client options for connecting to the test database, use the [PostgreSQL environment variables](https://www.postgresql.org/docs/12/libpq-envars.html).


### PR DESCRIPTION
This is what we do on Travis, but we forgot to update the docs here. 

Closes https://github.com/invenia/LibPQ.jl/pull/171