### PR TITLE
Add Documentation and Test-Case for DataFrame Upload using CSV.RowIterator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,8 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 [compat]
 BinaryProvider = "0.5"
 CEnum = "0.2"
-DataFrames = "0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20"
+CSV = "0.6.2"
+DataFrames = "0.21"
 Decimals = "0.4.1"
 DocStringExtensions = "0.8.0"
 Infinity = "0.2"
@@ -37,8 +38,9 @@ TimeZones = "0.9.2, 0.10, 0.11, 1"
 julia = "1"
 
 [extras]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DataFrames"]
+test = ["Test", "DataFrames", "CSV"]


### PR DESCRIPTION
Follow-up of
https://github.com/invenia/LibPQ.jl/pull/172

A test case for uploading a DataFrame using the CSV.RowIterator and a corresponding example to the documentation has been added.

I had to update the version number of DataFrames so that it is compatible to the most recent version of CSV.jl, but this should not be an issue because it is only a test dependency and all tests are still working for me.