### PR TITLE
RFC: Avoid having to use double-escape in regex string

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -386,10 +386,10 @@ _DEFAULT_TYPE_MAP[:tstzrange] = Interval{ZonedDateTime}
 _DEFAULT_TYPE_MAP[:daterange] = Interval{Date}
 
 # Matches anything but the start or end of an interval or a comma
-const RANGE_ITEM = "[^\\[\\(\\]\\),]*"
+const RANGE_ITEM = raw"[^\[\(\]\),]*"
 # Makes sure the string starts and ends with a bracket or parentheses and a comma separates
 # the items in the interval
-const RANGE_REGEX = Regex("^([\\[\\(])($RANGE_ITEM),($RANGE_ITEM)([\\]\\)])\$")
+const RANGE_REGEX = Regex(raw"^([\[\(])(" * RANGE_ITEM * "),(" * RANGE_ITEM * raw")([\]\)])$")
 get_bounds_type(ch::AbstractString) = ch in ("[", "]") ? Closed : Open
 
 function pqparse(::Type{Interval{T}}, str::AbstractString) where {T}

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -389,7 +389,7 @@ _DEFAULT_TYPE_MAP[:daterange] = Interval{Date}
 const RANGE_ITEM = raw"[^\[\(\]\),]*"
 # Makes sure the string starts and ends with a bracket or parentheses and a comma separates
 # the items in the interval
-const RANGE_REGEX = Regex(raw"^([\[\(])(" * RANGE_ITEM * "),(" * RANGE_ITEM * raw")([\]\)])$")
+const RANGE_REGEX = Regex(string(raw"^([\[\(])(", RANGE_ITEM, "),(", RANGE_ITEM, raw")([\]\)])$"))
 get_bounds_type(ch::AbstractString) = ch in ("[", "]") ? Closed : Open
 
 function pqparse(::Type{Interval{T}}, str::AbstractString) where {T}


### PR DESCRIPTION
This was bothering me when I was reviewing #184. I figured I would put it out there and see what people think