### PR TITLE
Remove unresolvable DataFrames versions from compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 [compat]
 BinaryProvider = "0.5"
 CEnum = "0.2"
-DataFrames = "0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20"
+DataFrames = "0.20, 0.21"
 Decimals = "0.4.1"
 DocStringExtensions = "0.8.0"
 Infinity = "0.2"


### PR DESCRIPTION
According to Pkg, the only versions compatible with `Tables [0.2, 1]` are `DataFrames [0.11.7, 0.12.0, 0.13.0-0.13.1, 0.20.1-0.20.2, 0.21.0-0.21.4]`. I've removed the incompatible versions. 