### PR TITLE
Increase linkcheck_timeout

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,7 +21,7 @@ makedocs(;
     sitename="LibPQ.jl",
     checkdocs=:exports,
     linkcheck=true,
-    linkcheck_timeout=20,
+    linkcheck_timeout=60,
     strict=true,
     authors="Eric Davies",
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,6 +21,7 @@ makedocs(;
     sitename="LibPQ.jl",
     checkdocs=:exports,
     linkcheck=true,
+    linkcheck_timeout=20,
     strict=true,
     authors="Eric Davies",
 )


### PR DESCRIPTION
Increase `linkcheck_timeout` to try and prevent `curl` timeout.

Attempt to fix #191 

Closes: #191 