### PR TITLE
Fix erroneous varchar whitespace stripping

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -101,6 +101,7 @@ is not in UTF-8.
 bytes_view(pqv::PQValue) = unsafe_wrap(Vector{UInt8}, data_pointer(pqv), num_bytes(pqv) + 1)
 
 Base.String(pqv::PQValue) = unsafe_string(pqv)
+Base.parse(::Type{String}, pqv::PQValue) = unsafe_string(pqv)
 Base.convert(::Type{String}, pqv::PQValue) = String(pqv)
 Base.length(pqv::PQValue) = length(string_view(pqv))
 Base.lastindex(pqv::PQValue) = lastindex(string_view(pqv))
@@ -153,8 +154,8 @@ _DEFAULT_TYPE_MAP[:numeric] = Decimal
 
 ## character
 # bpchar is char(n)
-function pqparse(::Type{String}, str::AbstractString)
-    return String(rstrip(str, ' '))
+function Base.parse(::Type{String}, pqv::PQValue{PQ_SYSTEM_TYPES[:bpchar]})
+    return String(rstrip(string_view(pqv), ' '))
 end
 # char is "char"
 _DEFAULT_TYPE_MAP[:char] = PQChar

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1101,6 +1101,8 @@ end
                         ("E'\\\\001'::bytea", UInt8[0o001]),
                         ("E'\\\\176'::bytea", UInt8[0o176]),
                         ("'hello'::char(10)", "hello"),
+                        ("'hello  '::char(10)", "hello"),
+                        ("'hello  '::varchar(10)", "hello  "),
                         ("'3'::\"char\"", LibPQ.PQChar('3')),
                         ("'t'::bool", true),
                         ("'T'::bool", true),


### PR DESCRIPTION
We had been using the method for `bpchar` as a fallback for all types, and had thus been stripping trailing whitespace. I've fixed that and added a test. Only `bpchar` has semantically-insignificant trailing whitespace.

I added `Base.parse(::Type{String}, pqv::PQValue) = unsafe_string(pqv)` back in as the default string fallback as it circumvents `string_view` entirely. 