### PR TITLE
Fix load! for non-string parameters

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -160,7 +160,7 @@ function load!(table::T, connection::Connection, query::AbstractString) where {T
             elseif val isa AbstractString
                 convert(String, val)
             else
-                string(val)
+                string_parameter(val)
             end
         end
         close(execute(stmt, parameters; throw_error=true))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -289,7 +289,7 @@ end
             table = (; data = [["foo", "bar"], ["baz"]])
             LibPQ.load!(table, conn, "INSERT INTO libpqjl_test (data) VALUES (\$1);")
 
-            # TODO: comapre entire tables once string array parsing is supported
+            # TODO: compare entire tables once string array parsing is supported
             result = execute(conn, "SELECT data[1] as data1 FROM libpqjl_test ORDER BY id;", not_null=true)
             retrieved = columntable(result)
             @test first.(table.data) == retrieved.data1


### PR DESCRIPTION
This was broken for e.g. arrays, and anything where the Julia string representation differed from the LibPQ string representation.

Fixes #204 