### PR TITLE
Add boundserror when indexing into an invalid column

### DIFF
--- a/src/results.jl
+++ b/src/results.jl
@@ -506,7 +506,7 @@ The returned value will be `missing` if `NULL`, or will be of the type specified
 [`column_types`](@ref).
 """
 function Base.getindex(jl_result::Result, row::Integer, col::Integer)
-    if isnull(jl_result, row, col)
+    if isnull(jl_result, row, column_number(jl_result, col))
         return missing
     else
         oid = column_oids(jl_result)[col]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -916,6 +916,7 @@ end
             @test data[1][2] == "bar"
             @test data[2].yes_nulls === missing
             @test data[2][2] === missing
+            @test_throws BoundsError data[1].fake_column
 
             # columns
             ct = Tables.columns(result)


### PR DESCRIPTION
Fix #211 

@c42f Is this a good enough error or do I need something better here? I wanted to use `BoundsError` but it's quite limited for display. 