### PR TITLE
Fix CI Tests and Artifact Cache Issues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,8 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.0"  # LTS
-          - "1"    # Latest Release
+          - "1"  # Latest Release
+        postgresql-version:
+          - latest
         os:
           - ubuntu-latest
           - macOS-latest
@@ -29,16 +30,41 @@ jobs:
           - x64
           - x86
         exclude:
-          # Test 32-bit only on Linux
+          # Don't test 32-bit on macOS
           - os: macOS-latest
             arch: x86
-          - os: windows-latest
-            arch: x86
         include:
-          # Add a 1.5 job because that's what Invenia actually uses
+          # Add a 1.0 job just to make sure we still support it
           - os: ubuntu-latest
-            version: 1.5
+            version: "1.0"
             arch: x64
+            postgresql-version: latest
+          # Add a 1.3 job because that's what Invenia actually uses
+          - os: ubuntu-latest
+            version: 1.3
+            arch: x64
+            postgresql-version: latest
+          # Add older supported PostgreSQL Versions
+          - os: ubuntu-latest
+            version: 1
+            arch: x64
+            postgresql-version: '12'
+          - os: ubuntu-latest
+            version: 1
+            arch: x64
+            postgresql-version: '11'
+          - os: ubuntu-latest
+            version: 1
+            arch: x64
+            postgresql-version: '10'
+          - os: ubuntu-latest
+            version: 1
+            arch: x64
+            postgresql-version: '9.6'
+          - os: ubuntu-latest
+            version: 1
+            arch: x64
+            postgresql-version: '9.5'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,9 +39,9 @@ jobs:
             version: "1.0"
             arch: x64
             postgresql-version: latest
-          # Add a 1.3 job because that's what Invenia actually uses
+          # Add a 1.5 job because that's what Invenia actually uses
           - os: ubuntu-latest
-            version: 1.3
+            version: 1.5
             arch: x64
             postgresql-version: latest
           # Add older supported PostgreSQL Versions

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,9 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1"  # Latest Release
-        postgresql-version:
-          - latest
+          - "1.0"  # LTS
+          - "1"    # Latest Release
         os:
           - ubuntu-latest
           - macOS-latest
@@ -30,56 +29,32 @@ jobs:
           - x64
           - x86
         exclude:
-          # Don't test 32-bit on macOS
+          # Test 32-bit only on Linux
           - os: macOS-latest
             arch: x86
+          - os: windows-latest
+            arch: x86
         include:
-          # Add a 1.0 job just to make sure we still support it
+          # Add a 1.5 job because that's what Invenia actually uses
           - os: ubuntu-latest
-            version: "1.0"
+            version: 1.5
             arch: x64
-            postgresql-version: latest
-          # Add a 1.3 job because that's what Invenia actually uses
-          - os: ubuntu-latest
-            version: 1.3
-            arch: x64
-            postgresql-version: latest
-          # Add older supported PostgreSQL Versions
-          - os: ubuntu-latest
-            version: 1
-            arch: x64
-            postgresql-version: '12'
-          - os: ubuntu-latest
-            version: 1
-            arch: x64
-            postgresql-version: '11'
-          - os: ubuntu-latest
-            version: 1
-            arch: x64
-            postgresql-version: '10'
-          - os: ubuntu-latest
-            version: 1
-            arch: x64
-            postgresql-version: '9.6'
-          - os: ubuntu-latest
-            version: 1
-            arch: x64
-            postgresql-version: '9.5'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         env:
           cache-name: cache-artifacts
         with:
           path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
+            ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ matrix.arch }}-test-
+            ${{ runner.os }}-${{ matrix.arch }}-
             ${{ runner.os }}-
       # Linux
       - name: Install PostgreSQL

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -17,16 +17,14 @@ jobs:
         with:
           version: nightly
           arch: x64
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         env:
-          cache-name: cache-artifacts
+          cache-name: julia-nightly-cache-artifacts
         with:
           path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          key: ${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+            ${{ env.cache-name }}-
       - uses: harmon758/postgresql-action@v1
         with:
           postgresql version: latest


### PR DESCRIPTION
Use CLI script to automatically replace the 1.3 test with a 1.5 test (if necessary), as well as use new cache steps to cache the julia build artifacts