### PR TITLE
Allow postgres-in-docker to be used for testing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -41,6 +41,7 @@ julia = "1"
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
-test = ["Test", "DataFrames"]
+test = ["Test", "DataFrames", "Random"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using IterTools: imap
 using Memento
 using Memento.TestUtils
 using OffsetArrays
+using Random
 using TimeZones
 using Tables
 
@@ -68,11 +69,51 @@ end
     end
 end
 
-@testset "Online" begin
+USE_DOCKER_POSTGRES = get(ENV, "LIBPQJL_USE_DOCKER_POSTGRES", nothing) == "true"
+if USE_DOCKER_POSTGRES
+    container_name = "LibPQ_test"
+    password = randstring(RandomDevice(), 20)
+    port = 15432
+    postgres_proc = run(```
+               docker run --rm --name $container_name
+                   -p 0.0.0.0:$port:5432/tcp
+                   -e POSTGRES_USER=postgres
+                   -e POSTGRES_PASSWORD=$password
+                   -e POSTGRES_DB=postgres
+                   postgres:12.4
+               ```, wait=false)
+    DATABASE_HOST = "host=localhost port=$port password=$password"
+    DATABASE_USER = "postgres"
+    CONNECTION_STRING = "$DATABASE_HOST dbname=postgres user=postgres"
+    for i=1:100
+        # Wait for server to come up
+        if process_exited(postgres_proc)
+            error("docker postgres process exited unexpectedly")
+        end
+        sleep(5)
+        try
+            conn = LibPQ.Connection(CONNECTION_STRING)
+            break
+        catch
+            @info """Expected error message from LibPQ means we're waiting
+                  for the container to start"""
+        end
+    end
+    @test process_running(postgres_proc)
+
+    atexit() do
+        kill(postgres_proc, Base.SIGINT)
+    end
+else
+    DATABASE_HOST = ""
     DATABASE_USER = get(ENV, "LIBPQJL_DATABASE_USER", "postgres")
+    CONNECTION_STRING = "dbname=postgres user=$DATABASE_USER"
+end
+
+@testset "Online" begin
 
     @testset "Example SELECT" begin
-        conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=false)
+        conn = LibPQ.Connection(CONNECTION_STRING; throw_error=false)
         @test conn isa LibPQ.Connection
         @test isopen(conn)
         @test status(conn) == LibPQ.libpq_c.CONNECTION_OK
@@ -180,7 +221,7 @@ end
     end
 
     @testset "Example INSERT and DELETE" begin
-        conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER")
+        conn = LibPQ.Connection(CONNECTION_STRING)
 
         result = execute(conn, """
             CREATE TEMPORARY TABLE libpqjl_test (
@@ -277,7 +318,7 @@ end
 
     @testset "load!" begin
         @testset "issue #204" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER")
+            conn = LibPQ.Connection(CONNECTION_STRING)
 
             close(execute(conn, """
                 CREATE TEMPORARY TABLE libpqjl_test (
@@ -301,7 +342,7 @@ end
 
     @testset "COPY FROM" begin
         @testset "Example COPY FROM" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER")
+            conn = LibPQ.Connection(CONNECTION_STRING)
 
             result = execute(conn, """
                 CREATE TEMPORARY TABLE libpqjl_test (
@@ -345,7 +386,7 @@ end
         end
 
         @testset "Wrong column order" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER")
+            conn = LibPQ.Connection(CONNECTION_STRING)
 
             result = execute(conn, """
                 CREATE TEMPORARY TABLE libpqjl_test (
@@ -402,7 +443,7 @@ end
         @testset "do" begin
             local saved_conn
 
-            was_open = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true) do jl_conn
+            was_open = LibPQ.Connection(CONNECTION_STRING; throw_error=true) do jl_conn
                 saved_conn = jl_conn
                 return isopen(jl_conn)
             end
@@ -410,7 +451,7 @@ end
             @test was_open
             @test !isopen(saved_conn)
 
-            @test_throws LibPQ.Errors.PQConnectionError LibPQ.Connection("dbname=123fake user=$DATABASE_USER"; throw_error=true) do jl_conn
+            @test_throws LibPQ.Errors.PQConnectionError LibPQ.Connection("$DATABASE_HOST dbname=123fake user=$DATABASE_USER"; throw_error=true) do jl_conn
                 saved_conn = jl_conn
                 @test false
             end
@@ -419,14 +460,14 @@ end
         end
 
         @testset "Version Numbers" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             # update this test before PostgreSQL 20.0 ;)
             @test LibPQ.pqv"7" <= LibPQ.server_version(conn) <= LibPQ.pqv"20"
         end
 
         @testset "Encoding" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             @test LibPQ.encoding(conn) == "UTF8"
 
@@ -453,7 +494,7 @@ end
 
         @testset "Options" begin
             conn = LibPQ.Connection(
-                "dbname=postgres user=$DATABASE_USER";
+                CONNECTION_STRING;
                 options=Dict("IntervalStyle" => "postgres_verbose"),
                 throw_error=true,
                 type_map=Dict(:interval => String),
@@ -491,13 +532,13 @@ end
                 merge!(LibPQ.CONNECTION_PARAMETER_DEFAULTS, LibPQ._connection_parameter_dict(connection_options=LibPQ.CONNECTION_OPTION_DEFAULTS))
                 withenv("PGTZ" => nothing) do  # unset
                     LibPQ.Connection(
-                        "dbname=postgres user=$DATABASE_USER"; throw_error=true
+                        CONNECTION_STRING; throw_error=true
                     ) do conn
                         @test connection_tz(conn) == "America/Scoresbysund"
                     end
 
                     LibPQ.Connection(
-                        "dbname=postgres user=$DATABASE_USER";
+                        CONNECTION_STRING;
                         options=Dict("TimeZone" => "America/Danmarkshavn"),
                         throw_error=true,
                     ) do conn
@@ -505,7 +546,7 @@ end
                     end
 
                     LibPQ.Connection(
-                        "dbname=postgres user=$DATABASE_USER";
+                        CONNECTION_STRING;
                         options=Dict("TimeZone" => ""),
                         throw_error=true,
                     ) do conn
@@ -519,13 +560,13 @@ end
                 # does not have this problem. Perhaps we need to set some dlopen option?
                 withenv("PGTZ" => "America/Thule") do
                     LibPQ.Connection(
-                        "dbname=postgres user=$DATABASE_USER"; throw_error=true
+                        CONNECTION_STRING; throw_error=true
                     ) do conn
                         @test_broken_on_windows connection_tz(conn) == "America/Thule"
                     end
 
                     LibPQ.Connection(
-                        "dbname=postgres user=$DATABASE_USER";
+                        CONNECTION_STRING;
                         options=Dict("TimeZone" => "America/Danmarkshavn"),
                         throw_error=true,
                     ) do conn
@@ -533,7 +574,7 @@ end
                     end
 
                     LibPQ.Connection(
-                        "dbname=postgres user=$DATABASE_USER";
+                        CONNECTION_STRING;
                         options=Dict("TimeZone" => ""),
                         throw_error=true,
                     ) do conn
@@ -544,14 +585,14 @@ end
                 withenv("PGTZ" => "") do
                     @test_nolog_on_windows LibPQ.LOGGER "error" "invalid value for parameter" try
                         LibPQ.Connection(
-                            "dbname=postgres user=$DATABASE_USER"; throw_error=true
+                            CONNECTION_STRING; throw_error=true
                         )
                     catch
                     end
 
                     @test_nolog_on_windows LibPQ.LOGGER "error" "invalid value for parameter" try
                         LibPQ.Connection(
-                            "dbname=postgres user=$DATABASE_USER";
+                            CONNECTION_STRING;
                             options=Dict("TimeZone" => "America/Danmarkshavn"),
                             throw_error=true,
                         )
@@ -560,7 +601,7 @@ end
 
                     @test_nolog_on_windows LibPQ.LOGGER "error" "invalid value for parameter" try
                         LibPQ.Connection(
-                            "dbname=postgres user=$DATABASE_USER";
+                            CONNECTION_STRING;
                             options=Dict("TimeZone" => ""),
                             throw_error=true,
                         )
@@ -576,7 +617,7 @@ end
 
         @testset "Finalizer" begin
             closed_flags = map(1:50) do _
-                conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER")
+                conn = LibPQ.Connection(CONNECTION_STRING)
                 closed = conn.closed
                 finalize(conn)
                 return closed
@@ -590,7 +631,7 @@ end
             results = LibPQ.Result[]
 
             closed_flags = map(1:50) do _
-                conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER")
+                conn = LibPQ.Connection(CONNECTION_STRING)
                 push!(results, execute(conn, "SELECT 1;"))
                 return conn.closed
             end
@@ -605,7 +646,7 @@ end
 
             # with AsyncResults, which hold a reference to Connection
             closed_flags = asyncmap(1:50) do _
-                conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER")
+                conn = LibPQ.Connection(CONNECTION_STRING)
                 wait(async_execute(conn, "SELECT pg_sleep(1);"))
                 return conn.closed
             end
@@ -634,7 +675,7 @@ end
             # I don't think it's actually possible to hit this error condition on Windows
             # I also don't know if it's possible to reproduce this, given how sockets seem
             # to work on Windows
-            @static if !Sys.iswindows()
+            if !Sys.iswindows() && !USE_DOCKER_POSTGRES
                 @testset "closed socket (EBADF)" begin
                     conn = LibPQ.libpq_c.PQconnectStart("dbname=123fake user=$DATABASE_USER")
                     close(Base.Libc.FILE(LibPQ.socket(conn), "r"))  # close socket
@@ -651,7 +692,7 @@ end
             end
 
             @testset "throw_error=false" begin
-                conn = LibPQ.Connection("dbname=123fake user=$DATABASE_USER"; throw_error=false)
+                conn = LibPQ.Connection("$DATABASE_HOST dbname=123fake user=$DATABASE_USER"; throw_error=false)
                 @test conn isa LibPQ.Connection
                 @test status(conn) == LibPQ.libpq_c.CONNECTION_BAD
                 @test isopen(conn)
@@ -667,9 +708,9 @@ end
             end
 
             @testset "throw_error=true" begin
-                @test_throws LibPQ.Errors.PQConnectionError LibPQ.Connection("dbname=123fake user=$DATABASE_USER"; throw_error=true)
+                @test_throws LibPQ.Errors.PQConnectionError LibPQ.Connection("$DATABASE_HOST dbname=123fake user=$DATABASE_USER"; throw_error=true)
 
-                conn = LibPQ.Connection("dbname=123fake user=$DATABASE_USER"; throw_error=false)
+                conn = LibPQ.Connection("$DATABASE_HOST dbname=123fake user=$DATABASE_USER"; throw_error=false)
                 @test conn isa LibPQ.Connection
                 @test status(conn) == LibPQ.libpq_c.CONNECTION_BAD
                 @test isopen(conn)
@@ -684,7 +725,7 @@ end
 
     @testset "Results" begin
         @testset "Nulls" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             result = execute(conn, "SELECT NULL"; throw_error=true)
             @test status(result) == LibPQ.libpq_c.PGRES_TUPLES_OK
@@ -768,7 +809,7 @@ end
         end
 
         @testset "Not Nulls" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             result = execute(conn, "SELECT NULL"; not_null=[false], throw_error=true)
             @test status(result) == LibPQ.libpq_c.PGRES_TUPLES_OK
@@ -893,7 +934,7 @@ end
         end
 
         @testset "Tables.jl" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             result = execute(conn, """
                 SELECT no_nulls, yes_nulls FROM (
@@ -935,7 +976,7 @@ end
         end
 
         @testset "Duplicate names" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             result = execute(conn, "SELECT 1 AS col, 2 AS col;", not_null=true, throw_error=true)
             columns = Tables.columns(result)
@@ -951,7 +992,7 @@ end
         end
 
         @testset "Uppercase Columns" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             result = execute(conn, "SELECT 1 AS \"Column\";")
             @test num_columns(result) == 1
@@ -969,7 +1010,7 @@ end
         end
 
         @testset "PQResultError" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             try
                 execute(conn, "SELECT log(-1);")
@@ -1016,7 +1057,7 @@ end
 
         @testset "Type Conversions" begin
             @testset "Deprecations" begin
-                conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+                conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
                 result = execute(conn, "SELECT 'infinity'::timestamp;")
 
@@ -1033,7 +1074,7 @@ end
             end
 
             @testset "Automatic" begin
-                conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+                conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
                 result = execute(conn, """
                     SELECT oid, typname, typlen, typbyval, typcategory
@@ -1064,7 +1105,7 @@ end
             end
 
             @testset "Overrides" begin
-                conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+                conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
                 result = execute(conn, "SELECT 4::bigint;")
                 @test first(first(result)) === Int64(4)
@@ -1103,7 +1144,7 @@ end
 
             @testset "Parsing" begin
                 @testset "Default Types" begin
-                    conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+                    conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
                     test_data = [
                         ("3", Cint(3)),
@@ -1243,7 +1284,7 @@ end
                 end
 
                 @testset "Specified Types" begin
-                    conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+                    conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
                     test_data = [
                         ("3", UInt, UInt(3)),
@@ -1311,7 +1352,7 @@ end
         end
 
         @testset "Parameters" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             @testset "Arrays" begin
                 result = execute(conn, "SELECT 'foo' = ANY(\$1)", [["bar", "foo"]])
@@ -1421,7 +1462,7 @@ end
 
         @testset "Query Errors" begin
             @testset "Syntax Errors" begin
-                conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+                conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
                 result = execute(conn, "SELORCT NUUL;"; throw_error=false)
                 @test status(result) == LibPQ.libpq_c.PGRES_FATAL_ERROR
@@ -1439,7 +1480,7 @@ end
             end
 
             @testset "Wrong No. Parameters" begin
-                conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+                conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
                 result = execute(conn, "SELORCT \$1;", String[]; throw_error=false)
                 @test status(result) == LibPQ.libpq_c.PGRES_FATAL_ERROR
@@ -1463,7 +1504,7 @@ end
         end
 
         @testset "Interface Errors" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             result = execute(
                 conn,
@@ -1480,7 +1521,7 @@ end
 
     @testset "Statements" begin
         @testset "No Params, Output" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             stmt = prepare(conn, "SELECT oid, typname FROM pg_type")
 
@@ -1501,7 +1542,7 @@ end
         end
 
         @testset "Params, Output" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             stmt = prepare(conn, "SELECT oid, typname FROM pg_type WHERE oid = \$1")
 
@@ -1530,7 +1571,7 @@ end
         trywait(ar::LibPQ.AsyncResult) = (try wait(ar) catch end; nothing)
 
         @testset "Basic" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             ar = async_execute(conn, "SELECT pg_sleep(2);"; throw_error=false)
             yield()
@@ -1552,7 +1593,7 @@ end
         end
 
         @testset "Parameters" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             ar = async_execute(
                 conn,
@@ -1584,7 +1625,7 @@ end
 
         # Ensures queries wait for previous query completion before starting
         @testset "Wait in line to complete" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             first_ar = async_execute(conn, "SELECT pg_sleep(4);")
             yield()
@@ -1613,7 +1654,7 @@ end
         end
 
         @testset "Cancel" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             # final query needs to be one that actually does something
             # on Windows, first query also needs to do something
@@ -1645,7 +1686,7 @@ end
         end
 
         @testset "Canceled by closing connection" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             # final query needs to be one that actually does something
             # on Windows, first query also needs to do something
@@ -1677,7 +1718,7 @@ end
         end
 
         @testset "FDWatcher: bad file descriptor (EBADF)" begin
-            conn = LibPQ.Connection("dbname=postgres user=$DATABASE_USER"; throw_error=true)
+            conn = LibPQ.Connection(CONNECTION_STRING; throw_error=true)
 
             ar = async_execute(conn, "SELECT pg_sleep(3); SELECT * FROM pg_type;")
             yield()


### PR DESCRIPTION
This adds docker support for running postgres during local testing. This
allows users to easily run the tests locally even if they don't have
postgres installed or don't easily have the version they'd like to test
with available in their package manager. Provided they have docker installed, of course.

Disabled by default. To enable, set

```julia
    ENV["LIBPQJL_USE_DOCKER_POSTGRES"] = "true"
```