### PR TITLE
Allow a prepared Statement to be called like a function

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,6 +26,14 @@ async_result = async_execute(conn, "SELECT typname FROM pg_type WHERE oid = \$1"
 result = fetch(async_result)
 data = columntable(result)
 
+# the same but with prepared statements
+stmt = prepare(conn, "SELECT typname FROM pg_type WHERE oid = \$1")
+result = execute(stmt, ["16"])
+data = columntable(result)
+# or
+result = stmt(["16"])
+data = columntable(result)
+
 close(conn)
 ```
 

--- a/src/statements.jl
+++ b/src/statements.jl
@@ -27,6 +27,8 @@ Base.broadcastable(stmt::Statement) = Ref(stmt)
 Create a prepared statement on the PostgreSQL server using libpq.
 The statement is given an generated unique name using [`unique_id`](@ref).
 
+Statements are executable either via `execute(stmt, args...; kwargs...)` or `stmt(args...; kwargs...)`
+
 !!! note
 
     Currently the statement is not explicitly deallocated, but it is deallocated at the end
@@ -158,4 +160,8 @@ function _execute_prepared(
         num_params == 0 ? C_NULL : zeros(Cint, num_params),  # all parameters in text format
         zero(Cint),  # return result in text format
     )
+end
+
+function (stmt::Statement)(args...; kwargs...)
+    execute(stmt, args...; kwargs...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1487,15 +1487,21 @@ end
             @test LibPQ.num_columns(stmt) == 2
             @test LibPQ.num_params(stmt) == 0
             @test LibPQ.column_names(stmt) == ["oid", "typname"]
+            
+            function _test_stmt_exec_1(result)
+                @test LibPQ.num_columns(result) == 2
+                @test LibPQ.column_names(result) == ["oid", "typname"]
+                @test LibPQ.column_types(result) == [LibPQ.Oid, String]
+                @test LibPQ.num_rows(result) > 0
+
+                close(result)
+            end
 
             result = execute(stmt; throw_error=true)
+            _test_stmt_exec_1(result)
 
-            @test LibPQ.num_columns(result) == 2
-            @test LibPQ.column_names(result) == ["oid", "typname"]
-            @test LibPQ.column_types(result) == [LibPQ.Oid, String]
-            @test LibPQ.num_rows(result) > 0
-
-            close(result)
+            result = stmt(; throw_error=true)
+            _test_stmt_exec_1(result)
 
             close(conn)
         end
@@ -1508,19 +1514,25 @@ end
             @test LibPQ.num_columns(stmt) == 2
             @test LibPQ.num_params(stmt) == 1
             @test LibPQ.column_names(stmt) == ["oid", "typname"]
+            
+            function _test_stmt_exec_2(result)
+                @test LibPQ.num_columns(result) == 2
+                @test LibPQ.column_names(result) == ["oid", "typname"]
+                @test LibPQ.column_types(result) == [LibPQ.Oid, String]
+                @test LibPQ.num_rows(result) == 1
+
+                data = columntable(result)
+                @test data[:oid][1] == 16
+                @test data[:typname][1] == "bool"
+
+                close(result)
+            end
 
             result = execute(stmt, [16]; throw_error=true)
+            _test_stmt_exec_2(result)
 
-            @test LibPQ.num_columns(result) == 2
-            @test LibPQ.column_names(result) == ["oid", "typname"]
-            @test LibPQ.column_types(result) == [LibPQ.Oid, String]
-            @test LibPQ.num_rows(result) == 1
-
-            data = columntable(result)
-            @test data[:oid][1] == 16
-            @test data[:typname][1] == "bool"
-
-            close(result)
+            result = stmt([16]; throw_error=true)
+            _test_stmt_exec_2(result)
 
             close(conn)
         end


### PR DESCRIPTION
I'm aware that this maybe doesn't go entirely hand-in-hand with the intent of this library, but here's my pitch:

I've noticed that, in my own workflow, I often construct a `Statement` ahead of time and then call `execute` on it several times later.

In a lot of ways, the way I treat the `Statement` is how I might treat a function, except I can't call it directly.

I personally think it would be Julia-idiomatic for a `Statement` to be a functor that can be called, e.g.:
```
stmt = LibPQ.prepare("... \$1;")
data = [["hello"], ["world"]]
map(stmt, data)
```

I have also added tests to make sure that the current `Statement` tests also yield the same results using the functor call, and I have added some degree of documentation.