### PR TITLE
Update tested PostgreSQL versions to Supported Versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,6 +48,10 @@ jobs:
           - os: ubuntu-latest
             version: 1
             arch: x64
+            postgresql-version: '13'
+          - os: ubuntu-latest
+            version: 1
+            arch: x64
             postgresql-version: '12'
           - os: ubuntu-latest
             version: 1
@@ -61,10 +65,6 @@ jobs:
             version: 1
             arch: x64
             postgresql-version: '9.6'
-          - os: ubuntu-latest
-            version: 1
-            arch: x64
-            postgresql-version: '9.5'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
This change drops testing on PostgreSQL 9.5 and adds it on PostgreSQL 13.
This matches PostgreSQL's official Supported Versions.
You can see supported versions listed on any PostgreSQL [docs page](https://www.postgresql.org/docs/current/pgstatstatements.html).