### PR TITLE
Fix PQnotifies to return Ptr{pgNotify}

### DIFF
--- a/src/headers/libpq-fe.jl
+++ b/src/headers/libpq-fe.jl
@@ -535,7 +535,7 @@ function PQconsumeInput(conn)
 end
 
 function PQnotifies(conn)
-    ccall((:PQnotifies, LIBPQ_HANDLE), Ptr{PGnotify}, (Ptr{PGconn},), conn)
+    ccall((:PQnotifies, LIBPQ_HANDLE), Ptr{pgNotify}, (Ptr{PGconn},), conn)
 end
 
 function PQputCopyData(conn, buffer, nbytes)


### PR DESCRIPTION
This is related to https://github.com/invenia/LibPQ.jl/issues/242

The fix allows one to use [LISTEN](https://www.postgresql.org/docs/9.1/sql-listen.html) and [NOTIFY](https://www.postgresql.org/docs/9.1/sql-notify.html).

See the following minimum working example:
```julia
using LibPQ

lpqc = LibPQ.libpq_c

function onenotify()
    conn = lpqc.PQconnectdb("host=localhost port=5432 dbname=db user=user password=pass")
    res = lpqc.PQexec(conn, "LISTEN virtual")
    lpqc.PQclear(res)
    relname = ""
    payload = ""

    @info "Listeing to channel..."
    while true
        notify = lpqc.PQnotifies(conn)
        if notify != C_NULL
            n = unsafe_load(notify)
            relname = unsafe_string(n.relname)
            payload = unsafe_string(n.extra)
            break
        end
        lpqc.PQfreeNotify(notify)
        lpqc.PQconsumeInput(conn)
        sleep(1)
    end
    lpqc.PQfinish(conn)
    (relname, payload)
end

channel, payload = onenotify()
@info "Received message from channel \"$channel\" with payload: $payload"
```

When one runs the above in a julia session, and in a separate `psql` session the following is issued:
```
db=> notify virtual, 'payload';
NOTIFY
```

Then the julia session receives the message:
```julia
[ Info: Received message from channel "virtual" with payload: payload
```