### PR TITLE
Start PostgreSQL in macOS CI from the new standard place

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,7 +102,7 @@ jobs:
           echo "LIBPQJL_DATABASE_USER=$USER" >> $GITHUB_ENV
         if: ${{ runner.os == 'macOS' }}
       - name: Start Homebrew PostgreSQL service
-        run: pg_ctl -D /usr/local/var/postgres start
+        run: pg_ctl -D /usr/local/var/postgresql@$(psql --version | cut -f3 -d' ' | cut -f1 -d.) start
         if: ${{ runner.os == 'macOS' }}
       # Windows
       - name: Add PostgreSQL to Path


### PR DESCRIPTION
This location used to be shared across all versions, now after a Homebrew formula change it's based in one specific place per version. Unfortunately, GitHub Actions may change what version is installed, so we need to discover that version dynamically. 