### PR TITLE
Support newer DataFrames versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LibPQ"
 uuid = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
 license = "MIT"
-version = "1.14.0"
+version = "1.14.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
-DataFrames = "0.20, 0.21"
+DataFrames = "0.20, 0.21, 0.22, 1"
 Decimals = "0.4.1"
 DocStringExtensions = "0.8.0, 0.9.1"
 Infinity = "0.2"


### PR DESCRIPTION
The docs are still pinned to 0.21 but they should probably be updated at some point. 

I ran the tests locally with 0.22, 1.0, and 1.3 and they all worked. 