### PR TITLE
Support and default to UUID for PostgreSQL uuid

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 SQLStrings = "af517c2e-c243-48fa-aab8-efac3db270f5"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"

--- a/src/LibPQ.jl
+++ b/src/LibPQ.jl
@@ -28,6 +28,7 @@ using Memento: Memento, getlogger, warn, info, error, debug
 using OffsetArrays
 using SQLStrings
 using TimeZones
+using UUIDs: UUID
 
 const Parameter = Union{String,Missing}
 const LOGGER = getlogger(@__MODULE__)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -211,6 +211,12 @@ function pqparse(::Type{Vector{UInt8}}, bytes::Array{UInt8,1})
     return unescaped_vec
 end
 
+## uuid
+_DEFAULT_TYPE_MAP[:uuid] = UUID
+function Base.parse(::Type{UUID}, pqv::PQBinaryValue{PQ_SYSTEM_TYPES[:uuid]})
+    return UUID(pqparse(UInt128, data_pointer(pqv)))
+end
+
 ## bool
 # TODO: check whether we ever need this or if PostgreSQL always gives t or f
 _DEFAULT_TYPE_MAP[:bool] = Bool
@@ -664,7 +670,7 @@ function array_size(str)
     return dims
 end
 
-for pq_eltype in ("int2", "int4", "int8", "float4", "float8", "oid", "numeric")
+for pq_eltype in ("int2", "int4", "int8", "float4", "float8", "oid", "numeric", "uuid")
     array_oid = PQ_SYSTEM_TYPES[Symbol("_$pq_eltype")]
     jl_type = _DEFAULT_TYPE_MAP[Symbol(pq_eltype)]
     jl_missingtype = Union{jl_type,Missing}


### PR DESCRIPTION
Closes https://github.com/invenia/LibPQ.jl/issues/260

This adds binary format parsing for UUID and sets the default Julia type for PostgreSQL's `uuid` to `Base.UUID`. The import relies on the UUIDs stdlib export for stability's sake. 

Array support was easy enough to add as well. 

Open question on whether changing the default type away from the `String` fallback needs a major version update: https://discourse.julialang.org/t/anyone-fetching-uuids-using-libpq-jl/89395/3

I think if people conclude it does, I'll change to ensure this doesn't set the default but still supports the same operations when UUID is specified. 