### PR TITLE
Add some illustrative options to LibPQ.Connection example to help new users

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,7 +16,7 @@ A Julia wrapper for the PostgreSQL `libpq` [C library](https://www.postgresql.or
 ```julia
 using LibPQ, Tables
 
-conn = LibPQ.Connection("dbname=postgres")
+conn = LibPQ.Connection("dbname=postgres host=localhost port=5432")
 result = execute(conn, "SELECT typname FROM pg_type WHERE oid = 16")
 data = columntable(result)
 


### PR DESCRIPTION
Replaces https://github.com/JuliaDatabases/LibPQ.jl/pull/298

I wanted to keep these more default, I kept the options different than the example below to hopefully illustrate that they're not mandatory.